### PR TITLE
fixed git pull

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /.idea
 /mxbuild
 ecj.jar
+/diagrams
+/docs

--- a/mx.py
+++ b/mx.py
@@ -3459,7 +3459,6 @@ class GitConfig(VC):
                 if abortOnError:
                     abort('fetch returned ' + str(rc))
                 return False
-        
 
     def can_push(self, vcdir, strict=True, abortOnError=True):
         """

--- a/mx.py
+++ b/mx.py
@@ -12265,7 +12265,7 @@ def main():
         # no need to show the stack trace when the user presses CTRL-C
         abort(1)
 
-version = VersionSpec("5.6.14")
+version = VersionSpec("5.6.15")
 
 currentUmask = None
 

--- a/mx.py
+++ b/mx.py
@@ -3437,24 +3437,24 @@ class GitConfig(VC):
         :return: True if the operation is successful, False otherwise
         :rtype: bool
         """
-        rc = self._fetch(vcdir, abortOnError)
-        if rc == 0 and update:
+        if update and not rev:
             active_branch = self._active_branch(vcdir, abortOnError)
-            if rev:
-                return self.update(vcdir, rev=rev, mayPull=False, clean=True, abortOnError=abortOnError)
-            else:
-                # refspec = '{0}:{1}'.format(rev if rev else 'HEAD', active_branch)
-                refspec = 'HEAD:{0}'.format(active_branch)
-                cmd = ['git', 'pull', 'origin', refspec]
-                self._log_pull(vcdir, rev)
-                out = OutputCapture()
-                rc = self.run(cmd, nonZeroIsFatal=abortOnError, cwd=vcdir, out=out)
-                logvv(out.data)
-                return rc == 0
+            cmd = ['git', 'pull', 'origin', 'HEAD:{0}'.format(active_branch)]
+            self._log_pull(vcdir, rev)
+            out = OutputCapture()
+            rc = self.run(cmd, nonZeroIsFatal=abortOnError, cwd=vcdir, out=out)
+            logvv(out.data)
+            return rc == 0
         else:
-            if abortOnError:
-                abort('fetch returned ' + str(rc))
-            return False
+            rc = self._fetch(vcdir, abortOnError)
+            if rc == 0:
+                if rev:
+                    return self.update(vcdir, rev=rev, mayPull=False, clean=True, abortOnError=abortOnError)
+            else:
+                if abortOnError:
+                    abort('fetch returned ' + str(rc))
+                return False
+        
 
     def can_push(self, vcdir, strict=True, abortOnError=True):
         """


### PR DESCRIPTION
Changed the behavior of GitConfig.pull. 
Original behavior: when update=True, do a git pull which works well when the refspec is not a commit hash.
New behavior: when update=True and rev not None, delegate to GitConfig.udpate (with force=True, discard local changes). Should this behavior be different? 

Bonus, updated GitConfig.update to suppress the "detached HEAD" warning messages when not in verbose mode. 

Bumped version to 5.6.15