### PR TITLE
Remove Python 2.6 compatibility testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.7"
 install:
-  - sudo pip install astroid==1.1.0
-  - sudo pip install pylint==1.1.0
+  - pip install astroid==1.1.0
+  - pip install pylint==1.1.0
   - pylint --version
 script: ./mx --strict-compliance gate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "2.6"
 install:
   - sudo pip install astroid==1.1.0
   - sudo pip install pylint==1.1.0


### PR DESCRIPTION
This removes all 2.6 compatibility testing as discussed in https://github.com/graalvm/mx/pull/11.