### PR TITLE
use checkstyle version 6.15

### DIFF
--- a/mx.mx/suite.py
+++ b/mx.mx/suite.py
@@ -57,7 +57,7 @@ suite = {
       }
     },
 
-    "CHECKSTYLE" : {
+    "CHECKSTYLE_6.0" : {
       "urls" : [
         "https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/checkstyle-6.0-all.jar",
         "jar:http://sourceforge.net/projects/checkstyle/files/checkstyle/6.0/checkstyle-6.0-bin.zip/download!/checkstyle-6.0/checkstyle-6.0-all.jar",
@@ -68,6 +68,20 @@ suite = {
         "groupId" : "com.puppycrawl.tools",
         "artifactId" : "checkstyle",
         "version" : "6.0",
+      }
+    },
+
+    "CHECKSTYLE_6.15" : {
+      "urls" : [
+        "https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/checkstyle-6.15-all.jar",
+        "jar:http://sourceforge.net/projects/checkstyle/files/checkstyle/6.15/checkstyle-6.15-all.jar",
+      ],
+      "sha1" : "db9ade7f4ef4ecb48e3f522873946f9b48f949ee",
+      "licence" : "LGPLv21",
+      "maven" : {
+        "groupId" : "com.puppycrawl.tools",
+        "artifactId" : "checkstyle",
+        "version" : "6.15",
       }
     },
 

--- a/mx.py
+++ b/mx.py
@@ -5426,8 +5426,8 @@ class SourceSuite(Suite):
                     javaCompliance = attrs.pop('javaCompliance', None)
                     if javaCompliance is None:
                         abort('javaCompliance property required for non-native project ' + name)
-                    checkstyleName = self.getMxCompatibility().checkstyleLibraryName()
-                    p = JavaProject(self, name, subDir, srcDirs, deps, javaCompliance, workingSets, d, checkstyleName, theLicense=theLicense)
+                    checkstyleLibraryName = self.getMxCompatibility().checkstyleLibraryName()
+                    p = JavaProject(self, name, subDir, srcDirs, deps, javaCompliance, workingSets, d, checkstyleLibraryName, theLicense=theLicense)
                     p.checkstyleProj = attrs.pop('checkstyle', name)
                     p.checkPackagePrefix = attrs.pop('checkPackagePrefix', 'true') == 'true'
                     ap = Suite._pop_list(attrs, 'annotationProcessors', context)

--- a/mx.py
+++ b/mx.py
@@ -1274,10 +1274,11 @@ class ProjectBuildTask(BuildTask):
         BuildTask.__init__(self, project, args, parallelism)
 
 class JavaProject(Project, ClasspathDependency):
-    def __init__(self, suite, name, subDir, srcDirs, deps, javaCompliance, workingSets, d, theLicense=None):
+    def __init__(self, suite, name, subDir, srcDirs, deps, javaCompliance, workingSets, d, checkstyleLibraryName, theLicense=None):
         Project.__init__(self, suite, name, subDir, srcDirs, deps, workingSets, d, theLicense)
         ClasspathDependency.__init__(self)
         self.checkstyleProj = name
+        self.checkstyleLibraryName = checkstyleLibraryName
         if javaCompliance is None:
             abort('javaCompliance property required for Java project ' + name)
         self.javaCompliance = JavaCompliance(javaCompliance)
@@ -5425,7 +5426,8 @@ class SourceSuite(Suite):
                     javaCompliance = attrs.pop('javaCompliance', None)
                     if javaCompliance is None:
                         abort('javaCompliance property required for non-native project ' + name)
-                    p = JavaProject(self, name, subDir, srcDirs, deps, javaCompliance, workingSets, d, theLicense=theLicense)
+                    checkstyleName = self.getMxCompatibility().checkstyleLibraryName()
+                    p = JavaProject(self, name, subDir, srcDirs, deps, javaCompliance, workingSets, d, checkstyleName, theLicense=theLicense)
                     p.checkstyleProj = attrs.pop('checkstyle', name)
                     p.checkPackagePrefix = attrs.pop('checkPackagePrefix', 'true') == 'true'
                     ap = Suite._pop_list(attrs, 'annotationProcessors', context)
@@ -8546,6 +8548,7 @@ def checkstyle(args):
             continue
         if args.primary and not p.suite.primary:
             continue
+        checkstyleLibrary = library(p.checkstyleLibraryName).get_path(True)
         sourceDirs = p.source_dirs()
 
         config = join(project(p.checkstyleProj).dir, '.checkstyle_checks.xml')
@@ -8594,11 +8597,10 @@ def checkstyle(args):
 
             auditfileName = join(p.dir, 'checkstyleOutput.txt')
             log('Running Checkstyle on {0} using {1}...'.format(sourceDir, config))
-
             try:
                 for chunk in _chunk_files_for_command_line(javafilelist):
                     try:
-                        run_java(['-Xmx1g', '-jar', library('CHECKSTYLE').get_path(True), '-f', 'xml', '-c', config, '-o', auditfileName] + chunk, nonZeroIsFatal=False)
+                        run_java(['-Xmx1g', '-jar', checkstyleLibrary, '-f', 'xml', '-c', config, '-o', auditfileName] + chunk, nonZeroIsFatal=False)
                     finally:
                         if exists(auditfileName):
                             errors = []
@@ -12283,7 +12285,7 @@ def main():
         # no need to show the stack trace when the user presses CTRL-C
         abort(1)
 
-version = VersionSpec("5.6.15")
+version = VersionSpec("5.6.16")
 
 currentUmask = None
 

--- a/mx_compat.py
+++ b/mx_compat.py
@@ -65,6 +65,9 @@ class MxCompatibility500(object):
     def mavenDeployJavadoc(self):
         return False
 
+    def checkstyleLibraryName(self):
+        return 'CHECKSTYLE_6.0'
+
     def __str__(self):
         return str("MxCompatibility({})".format(self.version()))
 
@@ -127,6 +130,14 @@ class MxCompatibility566(MxCompatibility555):
 
     def mavenDeployJavadoc(self):
         return True
+
+class MxCompatibility5616(MxCompatibility566):#pylint: disable=too-many-ancestors
+    @staticmethod
+    def version():
+        return mx.VersionSpec("5.6.16")
+
+    def checkstyleLibraryName(self):
+        return 'CHECKSTYLE_6.15'
 
 def minVersion():
     _ensureCompatLoaded()


### PR DESCRIPTION
The changes address issue #25. Suites that rely on older mx version will use Checkstyle 6.0, while newer ones will use 6.15.