### PR TITLE
Only call checkstyle on the primary suite in gate

### DIFF
--- a/mx_gate.py
+++ b/mx_gate.py
@@ -264,7 +264,7 @@ def gate(args):
             _warn_or_abort('ECLIPSE_EXE environment variable not set. Cannot execute CodeFormatCheck task.', args.strict_mode)
 
         with Task('Checkstyle', tasks) as t:
-            if t and mx.command_function('checkstyle')([]) != 0:
+            if t and mx.command_function('checkstyle')(['--primary']) != 0:
                 t.abort('Checkstyle warnings were found')
 
         with Task('Checkheaders', tasks) as t:


### PR DESCRIPTION
The dependent suites are already checked by their own gates.  Thus the previous
version did some unneeded checks.  This commit now prevents checkstyle checks
on dependent suites.