### PR TITLE
In the gate, run pylint and eclipseformat only on the primary suite.

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -8047,6 +8047,7 @@ def eclipseformat(args):
     parser.add_argument('-e', '--eclipse-exe', help='location of the Eclipse executable')
     parser.add_argument('-C', '--no-backup', action='store_false', dest='backup', help='do not save backup of modified files')
     parser.add_argument('--projects', action='store', help='comma separated projects to process (omit to process all projects)')
+    parser.add_argument('--primary', action='store_true', help='process only the projects that are part of the primary suite')
 
     args = parser.parse_args(args)
     if args.eclipse_exe is None:
@@ -8070,6 +8071,8 @@ def eclipseformat(args):
     if args.projects is not None:
         projectsToProcess = [project(name) for name in args.projects.split(',')]
     else:
+        if args.primary:
+            _opts.specific_suites = [_primary_suite.name]
         projectsToProcess = projects(True)
 
     class Batch:

--- a/mx_gate.py
+++ b/mx_gate.py
@@ -223,7 +223,7 @@ def gate(args):
 
         with Task('Pylint', tasks) as t:
             if t:
-                if mx.command_function('pylint')([]) != 0:
+                if mx.command_function('pylint')(['--primary']) != 0:
                     _warn_or_abort('Pylint not configured correctly. Cannot execute Pylint task.', args.strict_mode)
 
         gate_clean(cleanArgs, tasks)

--- a/mx_gate.py
+++ b/mx_gate.py
@@ -258,7 +258,7 @@ def gate(args):
         eclipse_exe = mx.get_env('ECLIPSE_EXE')
         if eclipse_exe is not None:
             with Task('CodeFormatCheck', tasks) as t:
-                if t and mx.command_function('eclipseformat')(['-e', eclipse_exe]) != 0:
+                if t and mx.command_function('eclipseformat')(['-e', eclipse_exe, '--primary']) != 0:
                     t.abort('Formatter modified files - run "mx eclipseformat", check in changes and repush')
         else:
             _warn_or_abort('ECLIPSE_EXE environment variable not set. Cannot execute CodeFormatCheck task.', args.strict_mode)


### PR DESCRIPTION
In the gates, pylint and eclipseformat run on the primary suite and on all imported suites. This is not always desirable since the imported suites should be already checked in their own gates. This pull request executes pylint and eclipseformat only on the primary suite when running the gate.