### PR TITLE
Gate eclipse task selection fix

### DIFF
--- a/mx_gate.py
+++ b/mx_gate.py
@@ -239,12 +239,13 @@ def gate(args):
                 if mx.command_function('canonicalizeprojects')([]) != 0:
                     t.abort('Rerun "mx canonicalizeprojects" and check-in the modified mx/suite*.py files.')
 
-        if mx.get_env('JDT'):
-            with Task('BuildJavaWithEcj', tasks) as t:
-                if t: mx.command_function('build')(['-p', '--no-native', '--warning-as-error'])
-            gate_clean(cleanArgs, tasks, name='CleanAfterEcjBuild')
-        else:
-            _warn_or_abort('JDT environment variable not set. Cannot execute BuildJavaWithEcj task.', args.strict_mode)
+        with Task('BuildJavaWithEcj', tasks) as t:
+            if t:
+                if mx.get_env('JDT'):
+                    mx.command_function('build')(['-p', '--no-native', '--warning-as-error'])
+                    gate_clean(cleanArgs, tasks, name='CleanAfterEcjBuild')
+                else:
+                    _warn_or_abort('JDT environment variable not set. Cannot execute BuildJavaWithEcj task.', args.strict_mode)
 
         with Task('BuildJavaWithJavac', tasks) as t:
             if t: mx.command_function('build')(['-p', '--warning-as-error', '--no-native', '--force-javac'])

--- a/mx_gate.py
+++ b/mx_gate.py
@@ -256,13 +256,14 @@ def gate(args):
                     mx.command_function('ideclean')([])
                     mx.command_function('ideinit')([])
 
-        eclipse_exe = mx.get_env('ECLIPSE_EXE')
-        if eclipse_exe is not None:
-            with Task('CodeFormatCheck', tasks) as t:
-                if t and mx.command_function('eclipseformat')(['-e', eclipse_exe]) != 0:
-                    t.abort('Formatter modified files - run "mx eclipseformat", check in changes and repush')
-        else:
-            _warn_or_abort('ECLIPSE_EXE environment variable not set. Cannot execute CodeFormatCheck task.', args.strict_mode)
+        with Task('CodeFormatCheck', tasks) as t:
+            if t:
+                eclipse_exe = mx.get_env('ECLIPSE_EXE')
+                if eclipse_exe is not None:
+                    if mx.command_function('eclipseformat')(['-e', eclipse_exe]) != 0:
+                        t.abort('Formatter modified files - run "mx eclipseformat", check in changes and repush')
+                else:
+                    _warn_or_abort('ECLIPSE_EXE environment variable not set. Cannot execute CodeFormatCheck task.', args.strict_mode)
 
         with Task('Checkstyle', tasks) as t:
             if t and mx.command_function('checkstyle')(['--primary']) != 0:


### PR DESCRIPTION
Currently, `mx gate` fails unconditionally if `JDT` or `ECLIPSE_EXE` is not available even in case the tasks which need those tools are not executed. With this change the check is only done if the tools are actually needed.