### PR TITLE
In the gate, run pylint and eclipseformat only on the primary suite.

### DIFF
--- a/mx_gate.py
+++ b/mx_gate.py
@@ -223,7 +223,7 @@ def gate(args):
 
         with Task('Pylint', tasks) as t:
             if t:
-                if mx.command_function('pylint')([]) != 0:
+                if mx.command_function('pylint')(['--primary']) != 0:
                     _warn_or_abort('Pylint not configured correctly. Cannot execute Pylint task.', args.strict_mode)
 
         gate_clean(cleanArgs, tasks)

--- a/mx_gate.py
+++ b/mx_gate.py
@@ -260,7 +260,7 @@ def gate(args):
             if t:
                 eclipse_exe = mx.get_env('ECLIPSE_EXE')
                 if eclipse_exe is not None:
-                    if mx.command_function('eclipseformat')(['-e', eclipse_exe]) != 0:
+                    if mx.command_function('eclipseformat')(['-e', eclipse_exe, '--primary']) != 0:
                         t.abort('Formatter modified files - run "mx eclipseformat", check in changes and repush')
                 else:
                     _warn_or_abort('ECLIPSE_EXE environment variable not set. Cannot execute CodeFormatCheck task.', args.strict_mode)


### PR DESCRIPTION
In the gates, pylint and eclipseformat run on the primary suite and on all imported suites. This is not always desirable since the imported suites should be already checked in their own gates. This pull request executes pylint and eclipseformat only on the primary suite when running the gate.