### PR TITLE
Make git revision checking more resilient

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -3673,7 +3673,7 @@ class GitConfig(VC):
             out = subprocess.check_output(['git', 'show', '--format=oneline', '-s', rev], cwd=vcdir)
             return out.strip().startswith(rev)
         except subprocess.CalledProcessError:
-            abort('exists failed')
+            return False
 
 
 


### PR DESCRIPTION
git show can return non-zero exit code when revision does not exist yet. Instead of aborting, we can just say that the revision does not exist yet.