### PR TITLE
feature: support tagging of gate tasks

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -12327,7 +12327,7 @@ def main():
         # no need to show the stack trace when the user presses CTRL-C
         abort(1)
 
-version = VersionSpec("5.6.16")
+version = VersionSpec("5.7.0")
 
 currentUmask = None
 

--- a/mx.py
+++ b/mx.py
@@ -6548,6 +6548,7 @@ class ArgParser(ArgumentParser):
             opts.ignored_projects += os.environ.get('IGNORED_PROJECTS', '').split(',')
 
             mx_gate._jacoco = opts.jacoco
+            mx_gate.Task.verbose = opts.verbose
         else:
             parser = ArgParser(parents=[self])
             parser.add_argument('commandAndArgs', nargs=REMAINDER, metavar='command args...')

--- a/mx_gate.py
+++ b/mx_gate.py
@@ -55,6 +55,8 @@ class Task:
     tags = None
     tagsExclude = False
 
+    verbose = False
+
     def __init__(self, title, tasks=None, disableJacoco=False, tags=None):
         self.tasks = tasks
         self.title = title
@@ -328,7 +330,7 @@ def gate(args):
 
     mx.log('Gate task times:')
     for t in tasks:
-        mx.log('  ' + str(t.duration) + '\t' + t.title)
+        mx.log('  ' + str(t.duration) + '\t' + t.title + ("" if not (Task.verbose and t.tags) else (' [' + ','.join(t.tags) + ']')))
     mx.log('  =======')
     mx.log('  ' + str(total.duration))
 


### PR DESCRIPTION
This change allows the use of _tags_ to specify groups of gate tasks. Every task can be equipped with a set of tags.

The user can select one or more tags using the `--tags` argument of the `mx gate` command. For instance `mx gate --tags style,build` executes all tasks which are tagged with `style` or `build` (logical _or_):
```
$ mx -v gate --dry-run --tags style,build
...
Gate task times:
  0:00:00.000024        Pylint [style]
  0:00:00.000024        Clean [build,style]
  0:00:00.000023        Distribution Overlap Check [style]
  0:00:00.000017        Canonicalization Check [style]
  0:00:00.000017        BuildJavaWithEcj [style]
  0:00:00.000018        BuildJavaWithJavac [build,style]
  0:00:00.000017        IDEConfigCheck [style]
  0:00:00.000029        CodeFormatCheck [style]
  0:00:00.000018        Checkstyle [style]
  0:00:00.000017        Checkheaders [style]
  0:00:00.000016        FindBugs [style]
  =======
  0:00:00.000871
```
Another example:
```
$ mx -v gate --dry-run --tags build
...
Gate task times:
  0:00:00.000032        Clean [build,style]
  0:00:00.000012        BuildJavaWithJavac [build,style]
  =======
  0:00:00.000284
```

It also respects the `-x` flags, which turns it into an exclusion filter. So `mx gate --tags style -x` omits all tasks which _only_ contain the `style` tag (logical _and_).
```
$ mx -v gate --dry-run --tags style -x
...
Gate task times:
  0:00:00.000014        Versions
  0:00:00.000012        JDKReleaseInfo
  0:00:00.000012        Clean [build,style]
  0:00:00.000012        BuildJavaWithJavac [build,style]
  =======
  0:00:00.000284
```
Example with two tags:
```
$ mx -v gate --dry-run --tags style,build -x
...
Gate task times:
  0:00:00.000017        Versions
  0:00:00.000013        JDKReleaseInfo
  =======
  0:00:00.000218
```

There are other possible interpretations for selection and inclusion/exclusion but I think this behavior is the most useful trade-off between functionality and complexity for our use case. This is of course open for discussion.

Note that it can not be used in conjunction with the filter options (`--task-filter`, `--start-at`).

This PR also introduces two tags, `style` and `build`, and applies them to the existing Tasks wherever appropriate. We could also add other _predefined_ tags like `Tags.test`. Note that suites are not restricted to the `Tags` class but can use any string.