### PR TITLE
Gate tagging support

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -12327,7 +12327,7 @@ def main():
         # no need to show the stack trace when the user presses CTRL-C
         abort(1)
 
-version = VersionSpec("5.6.16")
+version = VersionSpec("5.7.0")
 
 currentUmask = None
 

--- a/mx.py
+++ b/mx.py
@@ -6548,6 +6548,7 @@ class ArgParser(ArgumentParser):
             opts.ignored_projects += os.environ.get('IGNORED_PROJECTS', '').split(',')
 
             mx_gate._jacoco = opts.jacoco
+            mx_gate.Task.verbose = opts.verbose
         else:
             parser = ArgParser(parents=[self])
             parser.add_argument('commandAndArgs', nargs=REMAINDER, metavar='command args...')

--- a/mx_gate.py
+++ b/mx_gate.py
@@ -35,6 +35,7 @@ import mx
 Predefined Task tags.
 """
 class Tags:
+    always = 'always'
     style = 'style'
     build = 'build'
 
@@ -223,18 +224,21 @@ def gate(args):
     elif args.tags:
         Task.tags = args.tags.split(',')
         Task.tagsExclude = args.x
+        if not Task.tagsExclude:
+            # implicitly include 'always'
+            Task.tags += [Tags.always]
     elif args.x:
         mx.abort('-x option cannot be used without --task-filter or the --tags option')
 
     tasks = []
     total = Task('Gate')
     try:
-        with Task('Versions', tasks) as t:
+        with Task('Versions', tasks, tags=[Tags.always]) as t:
             if t:
                 mx.command_function('version')(['--oneline'])
                 mx.command_function('sversions')([])
 
-        with Task('JDKReleaseInfo', tasks) as t:
+        with Task('JDKReleaseInfo', tasks, tags=[Tags.always]) as t:
             if t:
                 jdkDirs = os.pathsep.join([mx.get_env('JAVA_HOME', ''), mx.get_env('EXTRA_JAVA_HOMES', '')])
                 for jdkDir in jdkDirs.split(os.pathsep):

--- a/mx_gate.py
+++ b/mx_gate.py
@@ -55,6 +55,8 @@ class Task:
     tags = None
     tagsExclude = False
 
+    verbose = False
+
     def __init__(self, title, tasks=None, disableJacoco=False, tags=None):
         self.tasks = tasks
         self.title = title
@@ -328,7 +330,7 @@ def gate(args):
 
     mx.log('Gate task times:')
     for t in tasks:
-        mx.log('  ' + str(t.duration) + '\t' + t.title)
+        mx.log('  ' + str(t.duration) + '\t' + t.title + ("" if not (Task.verbose and t.tags) else (' [' + ','.join(t.tags) + ']')))
     mx.log('  =======')
     mx.log('  ' + str(total.duration))
 


### PR DESCRIPTION
Based on #42. I'm doing this on top of the other pull request to save a version bump.

This adds a special tag `always` that's always implicitly included.

For example:
`mx -v gate --dry-run --tags build`
```
Gate task times:
  0:00:00.000013        Versions [always]
  0:00:00.000018        JDKReleaseInfo [always]
  0:00:00.000018        Clean [build,style]
  0:00:00.000016        BuildJavaWithJavac [build,style]
  =======
  0:00:00.000420
```

It can still be explicitly excluded:
`mx -v gate --dry-run --tags always,style -x`
```
Gate task times:
  0:00:00.000018        Clean [build,style]
  0:00:00.000016        BuildJavaWithJavac [build,style]
  =======
  0:00:00.000294
```