### PR TITLE
gate: add separate tag for style checks that require a build

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -12348,7 +12348,7 @@ def main():
         # no need to show the stack trace when the user presses CTRL-C
         abort(1)
 
-version = VersionSpec("5.8.0")
+version = VersionSpec("5.8.1")
 
 currentUmask = None
 


### PR DESCRIPTION
This makes it possible to parallelize gate checks better.

- The `style` tag will not run any build steps, and it will do all style checks that are possible without building.
- The `build` tag will do the minimal work to get a running binary (i.e. clean, javac).
- The `fullbuild` tag does an ecj build, javac build, ideinit and findbugs.