### PR TITLE
Compute the min heap size required to a Java program.

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -7509,7 +7509,7 @@ class JDKConfig:
 
     def run_java(self, args, nonZeroIsFatal=True, out=None, err=None, cwd=None, timeout=None, env=None, addDefaultArgs=True):
         cmd = [self.java] + self.processArgs(args, addDefaultArgs=addDefaultArgs)
-        return run(cmd, nonZeroIsFatal=nonZeroIsFatal, out=out, err=err, cwd=cwd)
+        return run(cmd, nonZeroIsFatal=nonZeroIsFatal, out=out, err=err, cwd=cwd, timeout=timeout)
 
     def bootclasspath(self, filtered=True):
         self._init_classpaths()

--- a/mx.py
+++ b/mx.py
@@ -68,6 +68,8 @@ import mx_sigtest
 import mx_gate
 import mx_compat
 
+ERROR_TIMEOUT = 0x700000000 # not 32 bits
+
 _mx_home = os.path.realpath(dirname(__file__))
 
 try:
@@ -7132,7 +7134,7 @@ def _waitWithTimeout(process, args, timeout, nonZeroIsFatal=True):
             else:
                 log(msg)
                 _kill_process_group(process.pid, signal.SIGKILL)
-                return 1
+                return ERROR_TIMEOUT
         delay = min(delay * 2, remaining, .05)
         time.sleep(delay)
 
@@ -7182,8 +7184,10 @@ def run_mx(args, suite=None, nonZeroIsFatal=True, out=None, err=None, timeout=No
 def run(args, nonZeroIsFatal=True, out=None, err=None, cwd=None, timeout=None, env=None, **kwargs):
     """
     Run a command in a subprocess, wait for it to complete and return the exit status of the process.
-    If the exit status is non-zero and `nonZeroIsFatal` is true, then mx is exited with
-    the same exit status.
+    If the command times out, it kills the subprocess and returns `ERROR_TIMEOUT` if `nonZeroIsFatal`
+    is false, otherwise it kills all subprocesses and raises a SystemExit exception.
+    If the exit status of the command is non-zero, mx is exited with the same exit status if
+    `nonZeroIsFatal` is true, otherwise the exit status is returned.
     Each line of the standard output and error streams of the subprocess are redirected to
     out and err if they are callable objects.
     """

--- a/mx.py
+++ b/mx.py
@@ -7131,8 +7131,7 @@ def _waitWithTimeout(process, args, timeout, nonZeroIsFatal=True):
                 abort(msg)
             else:
                 log(msg)
-                for p, _ in _currentSubprocesses:
-                    _kill_process_group(p.pid, signal.SIGKILL)
+                _kill_process_group(process.pid, signal.SIGKILL)
                 return 1
         delay = min(delay * 2, remaining, .05)
         time.sleep(delay)

--- a/mx.py
+++ b/mx.py
@@ -7061,7 +7061,8 @@ def run_java_min_heap(args, benchName='# MinHeap:', overheadFactor=1.5, referenc
     def run_with_heap(heap, args, timeout=timeout, suppressStderr=True, nonZeroIsFatal=False):
         log('Trying with ' + str(heap) + 'MB of heap...')
         with open(os.devnull, 'w') as fnull:
-            exitCode = run_java(['-Xmx' + str(heap) + 'M'] + args, nonZeroIsFatal=nonZeroIsFatal, out=out, err=fnull if suppressStderr else err, cwd=cwd, timeout=timeout, env=env, addDefaultArgs=addDefaultArgs)
+            vmArgs, pArgs = extract_VM_args(args=args, useDoubleDash=False, allowClasspath=True, defaultAllVMArgs=True)
+            exitCode = run_java(vmArgs + ['-Xmx' + str(heap) + 'M'] + pArgs, nonZeroIsFatal=nonZeroIsFatal, out=out, err=fnull if suppressStderr else err, cwd=cwd, timeout=timeout, env=env, addDefaultArgs=addDefaultArgs)
             if exitCode:
                 log('failed')
             else:


### PR DESCRIPTION
I added a command that computes the minimum heap size required to run a Java program within a certain overhead factor.

This required some changes to `run_java` (run with a timeout) and to `_waitWithTimeout` (the timeout of a subprocess should not be fatal).