### PR TITLE
Enabling check that every element in the API has its @since tag

### DIFF
--- a/mx.mx/suite.py
+++ b/mx.mx/suite.py
@@ -31,9 +31,9 @@ suite = {
 
     "CODESNIPPET-DOCLET" : {
       "urls" : [
-        "http://repo1.maven.org/maven2/org/apidesign/javadoc/codesnippet-doclet/0.7/codesnippet-doclet-0.7.jar",
+        "http://repo1.maven.org/maven2/org/apidesign/javadoc/codesnippet-doclet/0.9/codesnippet-doclet-0.9.jar",
       ],
-      "sha1" : "28aaf1920d83e1e7d994c50cd23576ef93195434",
+      "sha1" : "4de316ba4d1e646dc44f92e4b1c4501d79afe595",
     },
 
     "JUNIT" : {

--- a/mx.py
+++ b/mx.py
@@ -10694,6 +10694,7 @@ def javadoc(args, parser=None, docDir='javadoc', includeDeps=True, stdDoclet=Tru
              '-doclet', 'org.apidesign.javadoc.codesnippet.Doclet',
              '-docletpath', snippetslib,
              '-snippetpath', snippets,
+             '-verifysincepresent',
              '-sourcepath', sp] +
              ([] if jdk.javaCompliance < JavaCompliance('1.8') else ['-Xdoclint:none']) +
              (['-overview', overviewFile] if exists(overviewFile) else []) +

--- a/mx.py
+++ b/mx.py
@@ -10522,9 +10522,11 @@ def javadoc(args, parser=None, docDir='javadoc', includeDeps=True, stdDoclet=Tru
             if not added:
                 logv('[{0} - skipping {1}]'.format(reason, p.name))
     snippets = []
+    verifySincePresent = [];
     for p in projects_opt_limit_to_suites():
         if p.isJavaProject():
             snippets += p.source_dirs()
+            verifySincePresent = p.suite.getMxCompatibility().verifySincePresent()
     snippets = os.pathsep.join(snippets)
     snippetslib = library('CODESNIPPET-DOCLET').get_path(resolve=True)
 
@@ -10694,8 +10696,8 @@ def javadoc(args, parser=None, docDir='javadoc', includeDeps=True, stdDoclet=Tru
              '-doclet', 'org.apidesign.javadoc.codesnippet.Doclet',
              '-docletpath', snippetslib,
              '-snippetpath', snippets,
-             '-verifysincepresent',
              '-sourcepath', sp] +
+             verifySincePresent +
              ([] if jdk.javaCompliance < JavaCompliance('1.8') else ['-Xdoclint:none']) +
              (['-overview', overviewFile] if exists(overviewFile) else []) +
              groupargs +
@@ -12427,7 +12429,7 @@ def main():
         # no need to show the stack trace when the user presses CTRL-C
         abort(1)
 
-version = VersionSpec("5.8.1")
+version = VersionSpec("5.9.0")
 
 currentUmask = None
 

--- a/mx_compat.py
+++ b/mx_compat.py
@@ -68,6 +68,9 @@ class MxCompatibility500(object):
     def checkstyleLibraryName(self):
         return 'CHECKSTYLE_6.0'
 
+    def verifySincePresent(self):
+        return []
+
     def __str__(self):
         return str("MxCompatibility({})".format(self.version()))
 
@@ -138,6 +141,14 @@ class MxCompatibility5616(MxCompatibility566):#pylint: disable=too-many-ancestor
 
     def checkstyleLibraryName(self):
         return 'CHECKSTYLE_6.15'
+
+class MxCompatibility59(MxCompatibility5616):#pylint: disable=too-many-ancestors
+    @staticmethod
+    def version():
+        return mx.VersionSpec("5.9.0")
+
+    def verifySincePresent(self):
+        return ['-verifysincepresent']
 
 def minVersion():
     _ensureCompatLoaded()


### PR DESCRIPTION
Truffle repository requires that every element in the API has its own **@since** tag since https://github.com/graalvm/truffle/pull/86. To make sure we don't regress in this respect, we need to turn on some automatic check.

This proposal turns on printing of warnings for `mx javadoc --unified` when a **@since** tag is missing. The warnings are then interpreted by the Truffle mx customizations as errors and fail the build. Exactly what we need.