### PR TITLE
Check for existence of git commit without producing error output

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -3697,8 +3697,8 @@ class GitConfig(VC):
         """
         self.check_for_git()
         try:
-            out = subprocess.check_output(['git', 'show', '--format=oneline', '-s', rev], cwd=vcdir)
-            return out.strip().startswith(rev)
+            subprocess.check_output(['git', 'cat-file', '-e', rev], cwd=vcdir)
+            return True
         except subprocess.CalledProcessError:
             return False
 


### PR DESCRIPTION
The current implementation of exists for git produces worrisome output like so:

`fatal: bad object 7de96d3ba72f2d1a2a0ef39351a3db4764c74b9c`

This uses an alternate command cat-file which only produces an error code.  I tested it by winding the state of a repo back and gc'ing the commit I would need, and then running sforceimports.  It behaved as expected but without the scary output.