### PR TITLE
make Checkstyle version configurable per project

### DIFF
--- a/mx_compat.py
+++ b/mx_compat.py
@@ -65,8 +65,8 @@ class MxCompatibility500(object):
     def mavenDeployJavadoc(self):
         return False
 
-    def checkstyleLibraryName(self):
-        return 'CHECKSTYLE_6.0'
+    def checkstyleVersion(self):
+        return '6.0'
 
     def verifySincePresent(self):
         return []
@@ -139,8 +139,8 @@ class MxCompatibility5616(MxCompatibility566):#pylint: disable=too-many-ancestor
     def version():
         return mx.VersionSpec("5.6.16")
 
-    def checkstyleLibraryName(self):
-        return 'CHECKSTYLE_6.15'
+    def checkstyleVersion(self):
+        return '6.15'
 
 class MxCompatibility59(MxCompatibility5616):#pylint: disable=too-many-ancestors
     @staticmethod


### PR DESCRIPTION
This addresses #74.

A project can explicitly specify the Checkstyle version:
```
    "com.oracle.graal.graph.test" : {
      ...
      "checkstyleVersion" : "6.15",
      ...
    }
```
or inherit it along with the Checkstyle config from another project:
```
    "com.oracle.graal.graph" : {
      ...
      "checkstyleVersion" : "6.15",
      ...
    },
    "com.oracle.graal.graph.test" : {
      ...
      "checkstyle" : "com.oracle.graal.graph",
      ...
    }
```
