### PR TITLE
Provide release_version for class BinarySuite

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -5779,6 +5779,9 @@ class BinarySuite(Suite):
         # we do not cache the version because it changes in development
         return self.vc.parent(self.dir)
 
+    def release_version(self):
+        return self.version()
+
     def isDirty(self, abortOnError=True):
         # a binary suite can not be dirty
         return False


### PR DESCRIPTION
In mx.graal-core/mx_graal_8.py _updateGraalPropertiesFile() calls
release_version for the jvmci suite. In the binary suite usecase this
results in: AttributeError: BinarySuite instance has no attribute
'release_version'. To make jvmci usable as binary suite release_version
is provided for class BinarySuite.

See: https://github.com/graalvm/mx/issues/71