### PR TITLE
Add JMH and `mx microbench` command

### DIFF
--- a/mx.mx/suite.py
+++ b/mx.mx/suite.py
@@ -103,6 +103,13 @@ suite = {
         "version" : "1.3",
       }
     },
+
+    "JMH" : {
+      "sha1" : "7e1577cf6e1f1326b78a322d206fa9412fd41ae9",
+      "urls" : ["https://lafo.ssw.uni-linz.ac.at/pub/jmh/jmh-runner-1.11.2.jar"],
+      "sourceSha1" : "12a67f0dcdfe7e43218bf38c1d7fd766122a3dc7",
+      "sourceUrls" : ["https://lafo.ssw.uni-linz.ac.at/pub/jmh/jmh-runner-1.11.2-sources.jar"],
+    },
   },
 
   "licenses" : {

--- a/mx.py
+++ b/mx.py
@@ -12838,7 +12838,7 @@ def main():
         # no need to show the stack trace when the user presses CTRL-C
         abort(1)
 
-version = VersionSpec("5.13.0")
+version = VersionSpec("5.14.0")
 
 currentUmask = None
 

--- a/mx.py
+++ b/mx.py
@@ -67,6 +67,7 @@ import mx_findbugs
 import mx_sigtest
 import mx_gate
 import mx_compat
+import mx_microbench
 
 ERROR_TIMEOUT = 0x700000000 # not 32 bits
 
@@ -12505,6 +12506,7 @@ _commands = {
     'test': [test, '[options]'],
     'unittest' : [mx_unittest.unittest, '[unittest options] [--] [VM options] [filters...]', mx_unittest.unittestHelpSuffix],
     'minheap' : [run_java_min_heap, ''],
+    'microbench' : [mx_microbench.microbench, '[VM options] [-- [JMH options]]'],
 }
 _commandsToSuite = {}
 

--- a/mx_microbench.py
+++ b/mx_microbench.py
@@ -1,0 +1,112 @@
+#
+# ----------------------------------------------------------------------------------------------------
+#
+# Copyright (c) 2016, 2016, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+# ----------------------------------------------------------------------------------------------------
+
+import mx
+from argparse import ArgumentParser
+
+_microbench_executor = None
+
+def set_microbenchmark_executor(ex):
+    global _microbench_executor
+    assert _microbench_executor is None, 'cannot override microbenchmark executor twice'
+    _microbench_executor = ex
+
+
+def get_microbenchmark_executor():
+    if not _microbench_executor:
+        set_microbenchmark_executor(MicrobenchExecutor())
+    return _microbench_executor
+
+class MicrobenchExecutor(object):
+
+    def microbench(self, args):
+        """run JMH microbenchmark projects"""
+        parser = ArgumentParser(prog='mx microbench', description=microbench.__doc__,
+                                usage="%(prog)s [command options|VM options] [-- [JMH options]]")
+        parser.add_argument('--jar', help='Explicitly specify micro-benchmark location')
+        self.add_arguments(parser)
+
+        known_args, args = parser.parse_known_args(args)
+
+        vmArgs, jmhArgs = mx.extract_VM_args(args, useDoubleDash=True)
+        vmArgs = self.parseVmArgs(vmArgs)
+
+        # look for -f in JMH arguments
+        forking = True
+        for i in range(len(jmhArgs)):
+            arg = jmhArgs[i]
+            if arg.startswith('-f'):
+                if arg == '-f' and (i+1) < len(jmhArgs):
+                    arg += jmhArgs[i+1]
+                try:
+                    if int(arg[2:]) == 0:
+                        forking = False
+                except ValueError:
+                    pass
+
+        if known_args.jar:
+            # use the specified jar
+            args = ['-jar', known_args.jar]
+            if not forking:
+                args += vmArgs
+        else:
+            # find all projects with a direct JMH dependency
+            jmhProjects = []
+            for p in mx.projects_opt_limit_to_suites():
+                if 'JMH' in [x.name for x in p.deps]:
+                    jmhProjects.append(p.name)
+            cp = mx.classpath(jmhProjects)
+
+            # execute JMH runner
+            args = ['-cp', cp]
+            if not forking:
+                args += vmArgs
+            args += ['org.openjdk.jmh.Main']
+
+        if forking:
+            def quoteSpace(s):
+                if " " in s:
+                    return '"' + s + '"'
+                return s
+
+            forkedVmArgs = map(quoteSpace, self.parseForkedVmArgs(vmArgs))
+            args += ['--jvmArgsPrepend', ' '.join(forkedVmArgs)]
+        self.run_java(args + jmhArgs)
+
+    def add_arguments(self, parser):
+        pass
+
+    def run_java(self, args):
+        mx.run_java(args)
+
+    def parseVmArgs(self, vmArgs):
+        return vmArgs
+
+    def parseForkedVmArgs(self, vmArgs):
+        return vmArgs
+
+def microbench(args):
+    get_microbenchmark_executor().microbench(args)


### PR DESCRIPTION
Fixes #84. This change introduces the `mx microbench` command as known from graal-core.

The core functionality is implemented in `MicrobenchExecutor` which can be sub-classed by downstream projects and attached using `mx_microbench.set_microbench_executor`.