### PR TITLE
Make NativeTARDistribution usable

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -1150,7 +1150,7 @@ class NativeTARDistribution(Distribution):
             output = join(self.suite.dir, self.output)
             assert tarfilename
             with tarfile.open(tarfilename, 'r:') as tar:
-                log('Extract {} to {}'.format(tarfilename, output))
+                logv('Extracting {} to {}'.format(tarfilename, output))
                 tar.extractall(output)
 
     def prePush(self, f):

--- a/mx.py
+++ b/mx.py
@@ -5745,7 +5745,7 @@ class SourceSuite(Suite):
                 native = attrs.pop('native', False)
                 if native:
                     output = attrs.pop('output', None)
-                    results = Suite._pop_list(attrs, 'output', context)
+                    results = Suite._pop_list(attrs, 'results', context)
                     p = NativeProject(self, name, subDir, srcDirs, deps, workingSets, results, output, d, theLicense=theLicense)
                 else:
                     javaCompliance = attrs.pop('javaCompliance', None)


### PR DESCRIPTION
Fixes bugs/missing features that make NativeTARDistribution usable for binary deployment of non-java projects.
