### PR TITLE
support project javaCompliance value that ends with "+" as a lower bound

### DIFF
--- a/mx.mx/suite.py
+++ b/mx.mx/suite.py
@@ -145,7 +145,7 @@ suite = {
     "com.oracle.mxtool.compilerserver" : {
       "subDir" : "java",
       "sourceDirs" : ["src"],
-      "javaCompliance" : "1.7",
+      "javaCompliance" : "1.7+", # jdk7 or later
     },
   },
 }


### PR DESCRIPTION
Fixes this issue:
```
SystemExit: dependency named com.oracle.mxtool.compilerserver was not found:
  project com.oracle.mxtool.compilerserver was removed as Java compliance 1.7 cannot be satisfied by configured JDKs
```