### PR TITLE
Only forward SIGQUIT to the child Java process not the whole process group

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -8087,7 +8087,8 @@ def _send_sigquit():
             if get_os() == 'windows':
                 log("mx: implement me! want to send SIGQUIT to my child process")
             else:
-                _kill_process_group(p.pid, sig=signal.SIGQUIT)
+                # only send SIGQUIT to the child not the process group
+                os.kill(p.pid, signal.SIGQUIT)
             time.sleep(0.1)
 
 def abort(codeOrMessage, context=None):


### PR DESCRIPTION
mx tries to forward SIGQUIT to its children but currently it signals the whole process group which appears to contain mx itself, resulting a storm of SIGQUITs instead of a single SIGQUIT.

@gilles-duboscq I think this will let us make the buildbot timeout code do a few dumps spaced over time so we can see what's happening.