### PR TITLE
travis: execute gate with --strict-mode.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,11 @@ install:
   - pip install astroid==1.1.0
   - pip install pylint==1.1.0
   - pylint --version
-script: ./mx --strict-compliance gate
+  - |
+      export ECLIPSE_TAR=$TRAVIS_BUILD_DIR/../eclipse.tar.gz
+      wget https://lafo.ssw.uni-linz.ac.at/slavefiles/gate/eclipse-jdk8-linux-x86_64.tar.gz -O $ECLIPSE_TAR
+      tar -C $TRAVIS_BUILD_DIR/.. -xf $ECLIPSE_TAR
+      export ECLIPSE_EXE=$TRAVIS_BUILD_DIR/../eclipse/eclipse
+      export JDT=$TRAVIS_BUILD_DIR/ecj.jar
+      wget http://ftp.halifax.rwth-aachen.de/eclipse/eclipse/downloads/drops4/R-4.5.1-201509040015/ecj-4.5.1.jar -O $JDT
+script: ./mx --strict-compliance gate --strict-mode


### PR DESCRIPTION
The travis gate is currently not executed in `--strict-mode` which means a missing or wrong pylint is not a failure. As a side effect we also need `ecj` since this would also cause an error.