### PR TITLE
Use ecj-4.5.2 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ install:
       tar -C $TRAVIS_BUILD_DIR/.. -xf $ECLIPSE_TAR
       export ECLIPSE_EXE=$TRAVIS_BUILD_DIR/../eclipse/eclipse
       export JDT=$TRAVIS_BUILD_DIR/ecj.jar
-      wget http://ftp.halifax.rwth-aachen.de/eclipse/eclipse/downloads/drops4/R-4.5.1-201509040015/ecj-4.5.1.jar -O $JDT
+      wget http://ftp.halifax.rwth-aachen.de/eclipse/eclipse/downloads/drops4/R-4.5.2-201602121500/ecj-4.5.2.jar -O $JDT
 script: ./mx --strict-compliance gate --strict-mode


### PR DESCRIPTION
`ecj-4.5.1` is no longer available from this mirror. Switching to `ecj-4.5.2` not cause any further issues.