### PR TITLE
Adding Jackpot 3.0 support

### DIFF
--- a/mx.mx/suite.py
+++ b/mx.mx/suite.py
@@ -110,6 +110,13 @@ suite = {
       "sourceUrls" : ["https://lafo.ssw.uni-linz.ac.at/pub/jmh/jmh-runner-1.12-sources.jar"],
       "licence" : "GPLv2-CPE",
     },
+
+    "JACKPOT" : {
+      "urls" : [
+        "https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/jackpot-8.1-20151011.220626.jar",
+      ],
+      "sha1" : "b5f91770afd3b8ce645e7b967a1f266ab472053b",
+    },
   },
 
   "licenses" : {

--- a/mx.py
+++ b/mx.py
@@ -68,6 +68,7 @@ import mx_unittest
 import mx_findbugs
 import mx_sigtest
 import mx_gate
+import mx_jackpot
 import mx_compat
 import mx_microbench
 import mx_urlrewrites
@@ -13838,6 +13839,7 @@ _commands = {
     'ideclean': [ideclean, ''],
     'ideinit': [ideinit, ''],
     'intellijinit': [intellijinit, ''],
+    'jackpot': [mx_jackpot.jackpot, ''],
     'jacocoreport' : [mx_gate.jacocoreport, '[output directory]'],
     'archive': [_archive, '[options]'],
     'maven-install' : [maven_install, ''],
@@ -14222,7 +14224,7 @@ def main():
         # no need to show the stack trace when the user presses CTRL-C
         abort(1)
 
-version = VersionSpec("5.41.1")
+version = VersionSpec("5.42.0")
 
 currentUmask = None
 

--- a/mx_jackpot.py
+++ b/mx_jackpot.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python2.7
+#
+# ----------------------------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+# ----------------------------------------------------------------------------------------------------
+#
+
+import mx
+import os
+from os.path import join, exists
+
+def _should_test_project(p):
+    if not p.isJavaProject():
+        return False
+    if hasattr(p, 'jackpot'):
+        return p.jackpot.lower() == 'true'
+    if p.name.endswith('.test'):
+        return False
+    return True
+
+def jackpot(args, suite=None):
+    """run Jackpot 3.0 against non-test Java projects"""
+    jackpotHome = mx.get_env('JACKPOT_HOME', None)
+    if jackpotHome:
+        jackpotJar = join(jackpotHome, 'jackpot.jar')
+    else:
+        jackpotJar = mx.library('JACKPOT').get_path(resolve=True)
+    assert exists(jackpotJar)
+    if suite is None:
+        suite = mx._primary_suite
+    nonTestProjects = [p for p in mx.projects() if _should_test_project(p)]
+    if not nonTestProjects:
+        return 0
+    groups = []
+    for p in nonTestProjects:
+        javacClasspath = []
+
+        deps = []
+        p.walk_deps(visit=lambda dep, edge: deps.append(dep) if dep.isLibrary() or dep.isProject() else None)
+        annotationProcessorOnlyDeps = []
+        if len(p.annotation_processors()) > 0:
+            for apDep in p.annotation_processors():
+                if not apDep in deps:
+                    deps.append(apDep)
+                    annotationProcessorOnlyDeps.append(apDep)
+
+        for dep in deps:
+            if dep == p:
+                continue
+
+            if dep in annotationProcessorOnlyDeps:
+                continue
+
+            if dep.isLibrary():
+                path = dep.get_path(resolve=True)
+                if path:
+                    javacClasspath.append(path)
+
+            elif dep.isProject():
+                javacClasspath.append(dep.classpath_repr())
+
+        javaCompliance = p.javaCompliance
+
+        groups = groups + ['--group', "--classpath " + mx._separatedCygpathU2W(_escape_string(os.pathsep.join(javacClasspath))) + " --source " + str(p.javaCompliance) + " " + " ".join([_escape_string(d) for d in p.source_dirs()])]
+
+    cmd = ['-classpath', mx._cygpathU2W(jackpotJar), 'org.netbeans.modules.jackpot30.cmdline.Main']
+    cmd = cmd + ['--fail-on-warnings', '--progress'] + args + groups
+
+    return mx.run_java(cmd, nonZeroIsFatal=False, jdk=mx.get_jdk(javaCompliance))
+
+def _escape_string(s):
+    return s.replace("\\", "\\\\").replace(" ", "\\ ")


### PR DESCRIPTION
Hi,

This patch adds a support for Jackpot 3.0 - Jackpot 3.0 interprets custom hint files, and reports warnings as appropriate. To use it, it should suffice to do "mx jackpot", similarly to "mx findbugs".

Comments are welcome!

Thanks!