### PR TITLE
Use ecj-4.5.2.jar from eclipse archive for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ install:
       tar -C $TRAVIS_BUILD_DIR/.. -xf $ECLIPSE_TAR
       export ECLIPSE_EXE=$TRAVIS_BUILD_DIR/../eclipse/eclipse
       export JDT=$TRAVIS_BUILD_DIR/ecj.jar
-      wget http://ftp.halifax.rwth-aachen.de/eclipse/eclipse/downloads/drops4/R-4.5.2-201602121500/ecj-4.5.2.jar -O $JDT
+      wget http://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.5.2-201602121500/ecj-4.5.2.jar -O $JDT
 script: ./mx --strict-compliance gate --strict-mode


### PR DESCRIPTION
The original resource at http://ftp.halifax.rwth-aachen.de/eclipse/eclipse/downloads/drops4/R-4.5.2-201602121500/ecj-4.5.2.jar is not available anymore and travis builds fail because of that. I suggest to use https://lafo.ssw.uni-linz.ac.at/pub/sulong-deps/ecj-4.5.2.jar instead.