### PR TITLE
Fix error when trying to print unicode strings

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -9530,6 +9530,8 @@ def log_error(msg=None):
     if msg is None:
         print >> sys.stderr
     else:
+        if type(msg) is unicode:
+            msg = msg.encode('utf-8')
         print >> sys.stderr, colorize(str(msg), stream=sys.stderr)
 
 def expand_project_in_class_path_arg(cpArg):


### PR DESCRIPTION
Sadly, python has quite a bunch of handling issues regarding utf-8

I solved the error in this specific way, because it's possible log_error is called with some object where we want to have the string representation, and not directly using str or unicode.