### PR TITLE
Add JUnit config to intellijinit

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -13172,20 +13172,18 @@ def _intellij_suite(args, s, refreshOnly=False, mx_python_modules=False, java_mo
 
                 class DisabledUnittests(object):
                     """Context manager that temporarily disables unittests from launching.
-                    
+
                     It does this by replacing the mx.run with itself and examining the issued
                     commands. If it detects the `mx_unittest_main_class` in the command, it
                     captures the command and reports success without actually doing anything.
                     """
 
                     def __enter__(self):
-                        global run
                         self.run = run
-                        run = self      # replace mx.run
+                        globals()['run'] = self      # replace mx.run
 
                     def __exit__(self, exc_type, exc_val, exc_tb):
-                        global run
-                        run = self.run  # restore mx.run
+                        globals()['run'] = self.run  # restore mx.run
 
                     def __call__(self, args, **kwargs):
                         if mx_unittest_main_class in args:
@@ -13234,7 +13232,7 @@ def _intellij_suite(args, s, refreshOnly=False, mx_python_modules=False, java_mo
             # remove all whitespace between tags, so that we don't end up with excess newlines in xml output
             default_configuration = ''.join([line.strip() for line in default_configuration.splitlines()])
 
-            # until the official solution becomes available (IDEA-65915), use `workspase.xml`
+            # until the official solution becomes available (IDEA-65915), use `workspace.xml`
             wsXml = XMLDoc()
             wsXml.open('project', attributes={'version': '4'})
             wsXml.open('component', attributes={'name': 'RunManager'})

--- a/mx.py
+++ b/mx.py
@@ -13108,10 +13108,13 @@ def _intellij_suite(args, s, refreshOnly=False, mx_python_modules=False, java_mo
             # 1) Make an ant file for archiving the distributions.
             antXml = XMLDoc()
             antXml.open('project', attributes={'name': s.name, 'default': 'archive'})
+            antXml.element('dirname', attributes={'file': '${java.home}', 'property': 'java_home'})
             for dist in validDistributions:
                 antXml.open('target', attributes={'name': antTargetName(dist)})
-                antXml.open('exec', attributes={'executable': sys.executable})
+                antXml.open('exec', attributes={'executable': sys.executable, 'failonerror': 'true'})
                 antXml.element('arg', attributes={'value': join(_mx_home, 'mx.py')})
+                antXml.element('arg', attributes={'value': '--java-home'})
+                antXml.element('arg', attributes={'value': '${java_home}'})
                 antXml.element('arg', attributes={'value': 'archive'})
                 antXml.element('arg', attributes={'value': '@' + dist.name})
                 antXml.close('exec')
@@ -13274,10 +13277,13 @@ def ideclean(args):
         if exists(path):
             os.remove(path)
 
+    rm(join(_mx_suite.dir, basename(_mx_suite.dir) + '.iml'))
+
     for s in suites() + [_mx_suite]:
         rm(join(s.get_mx_output_dir(), 'eclipse-config.zip'))
         rm(join(s.get_mx_output_dir(), 'netbeans-config.zip'))
         shutil.rmtree(join(s.dir, '.idea'), ignore_errors=True)
+        rm(join(s.mxDir, basename(s.mxDir) + '.iml'))
 
     for p in projects() + _mx_suite.projects:
         if not p.isJavaProject():


### PR DESCRIPTION
Makes intellijinit generate default run/debug configuration for JUnit.

There are two aspects to proposed changes. First one is the placement of generated configuration. At the moment it is stored in the workspace.xml, since the official location is not available yet (IDEA-65915). And the second one is the collection of necessary VM parameters for JUnit to run. I tried to reuse mx unittest for that by effectively making it execute a dry run. This implementation of dry run only prevents tests from running. It doesn't prevent side effects, e.g., unittest's test discovery and caching. But since unittest allows custom launchers, i.e., implemented by other modules, I am not sure what can be expected from them in this regard. Graal core seems to work fine.