### PR TITLE
Fix intellijinit on Windows

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -120,6 +120,12 @@ class DynamicVarScope(object):
 
 currently_loading_suite = DynamicVar(None)
 
+def safe_relpath(path, start):
+    """Return a relative version of a path if possible. Otherwise just return path"""
+    try:
+        return os.path.relpath(path, start)
+    except ValueError:
+        return path
 
 # Support for Python 2.6
 def check_output(*popenargs, **kwargs):
@@ -12940,9 +12946,9 @@ def _intellij_suite(args, s, refreshOnly=False, mx_python_modules=False, java_mo
         for library in libraries:
             sourcePath = None
             if library.isLibrary():
-                path = os.path.relpath(library.get_path(True), s.dir)
+                path = safe_relpath(library.get_path(True), s.dir)
                 if library.sourcePath:
-                    sourcePath = os.path.relpath(library.get_source_path(True), s.dir)
+                    sourcePath = safe_relpath(library.get_source_path(True), s.dir)
             elif library.isMavenProject():
                 path = os.path.relpath(library.get_path(True), s.dir)
                 sourcePath = os.path.relpath(library.get_source_path(True), s.dir)
@@ -12986,7 +12992,7 @@ def _intellij_suite(args, s, refreshOnly=False, mx_python_modules=False, java_mo
                 for apDep in processors:
                     def processApDep(dep, edge):
                         if dep.isLibrary() or dep.isJARDistribution():
-                            compilerXml.element('entry', attributes={'name': '$PROJECT_DIR$/' + os.path.relpath(dep.path, s.dir)})
+                            compilerXml.element('entry', attributes={'name': '$PROJECT_DIR$/' + safe_relpath(dep.path, s.dir)})
                         elif dep.isProject():
                             compilerXml.element('entry', attributes={'name': '$PROJECT_DIR$/' + os.path.relpath(dep.output_dir(), s.dir)})
                     apDep.walk_deps(visit=processApDep)

--- a/mx.py
+++ b/mx.py
@@ -12994,7 +12994,7 @@ def _intellij_suite(args, s, refreshOnly=False, mx_python_modules=False, java_mo
                         if dep.isLibrary() or dep.isJARDistribution():
                             compilerXml.element('entry', attributes={'name': '$PROJECT_DIR$/' + safe_relpath(dep.path, s.dir)})
                         elif dep.isProject():
-                            compilerXml.element('entry', attributes={'name': '$PROJECT_DIR$/' + os.path.relpath(dep.output_dir(), s.dir)})
+                            compilerXml.element('entry', attributes={'name': '$PROJECT_DIR$/' + safe_relpath(dep.output_dir(), s.dir)})
                     apDep.walk_deps(visit=processApDep)
                 compilerXml.close('processorPath')
                 for module in modules:

--- a/mx.py
+++ b/mx.py
@@ -5666,7 +5666,7 @@ def _maven_deploy_dists(dists, versionGetter, repository_id, url, settingsXml, d
                         for filename in filenames:
                             emptyJavadoc = False
                             src = join(dirpath, filename)
-                            dst = os.path.relpath(src, javadocDir)
+                            dst = safe_relpath(src, javadocDir)
                             arc.write(src, dst)
                 shutil.rmtree(tmpDir)
                 if emptyJavadoc:
@@ -12950,12 +12950,12 @@ def _intellij_suite(args, s, refreshOnly=False, mx_python_modules=False, java_mo
                 if library.sourcePath:
                     sourcePath = safe_relpath(library.get_source_path(True), s.dir)
             elif library.isMavenProject():
-                path = os.path.relpath(library.get_path(True), s.dir)
-                sourcePath = os.path.relpath(library.get_source_path(True), s.dir)
+                path = safe_relpath(library.get_path(True), s.dir)
+                sourcePath = safe_relpath(library.get_source_path(True), s.dir)
             elif library.isJARDistribution():
-                path = os.path.relpath(library.path, s.dir)
+                path = safe_relpath(library.path, s.dir)
                 if library.sourcesPath:
-                    sourcePath = os.path.relpath(library.sourcesPath, s.dir)
+                    sourcePath = safe_relpath(library.sourcesPath, s.dir)
             else:
                 abort('Dependency not supported: {} ({})'.format(library.name, library.__class__.__name__))
             make_library(library.name, path, sourcePath)


### PR DESCRIPTION
Hi! I 've just tried to run 'mx.cmd intellijinit' for sulong project on windows and got following error:
```Traceback (most recent call last):
  File "T:\dev\sulong-dev\mx\/mx.py", line 15330, in <module>
    main()
  File "T:\dev\sulong-dev\mx\/mx.py", line 15314, in main
    retcode = c(command_args)
  File "T:\dev\sulong-dev\mx\/mx.py", line 12737, in intellijinit
    _intellij_suite(args, suite, refreshOnly, mx_python_modules, java_modules, suite != primary_suite())
  File "T:\dev\sulong-dev\mx\/mx.py", line 12959, in _intellij_suite
    path = os.path.relpath(library.get_path(True), s.dir)
  File "C:\Python27\lib\ntpath.py", line 529, in relpath
    % (path_prefix, start_prefix))
ValueError: path is on drive C:, start on drive T:```

The problem occured because I've put my dev directory on T: drive and temp files were under my user directory on C:

I've implemented the minimal fix for my scenario which shouldn't break anything and afterwards reviewed neighboorhood code and added few similar fixes "just in case".

This is my first PR to mx and first PR in Python, so please give any necessary feedback on how to improve it and get it merged. :)