### PR TITLE
_find_metadata_dir: fixed on Windows

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -12005,7 +12005,7 @@ def _get_jdk_module_jar(module, suite, jdk):
             ancestors of `start` and looking for ``*/src/<module>/share/classes``.
             """
             d = start
-            while len(d) != 0 and d != os.sep:
+            while len(d) != 0 and os.path.splitdrive(d)[1] != os.sep:
                 for subdir in os.listdir(d):
                     classes = join(d, subdir, 'src', module, 'share', 'classes')
                     if exists(classes):

--- a/mx.py
+++ b/mx.py
@@ -4032,7 +4032,7 @@ class VC(object):
     @staticmethod
     def _find_metadata_dir(start, name):
         d = start
-        while len(d) != 0 and d != os.sep:
+        while len(d) != 0 and os.path.splitdrive(d)[1] != os.sep:
             subdir = join(d, name)
             if exists(subdir):
                 return subdir


### PR DESCRIPTION
Without this fix _find_metadata_dir results in endless loop on Windows where `dirname('C:\\')` returns `'C:\\'` and this is not equal to `os.sep`. The `os.path.splitdrive(d)` splits it to `C:` and `\\`. Should be harmless on non-Windows systems. See the splitdrive [documentation](https://docs.python.org/2/library/os.path.html):

> os.path.**splitdrive**(*path*)
>
> Split the pathname path into a pair `(drive, tail)` where drive is either a drive specification or the empty string. On systems which do not use drive specifications, *drive* will always be the empty string. In all cases, `drive + tail` will be the same as path.

I'm not a Python guy, but hopefully the fix is ok.