### PR TITLE
Generate native headers during java compilation

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -2614,6 +2614,9 @@ class JavacLikeCompiler(JavaCompiler):
         disableApiRestrictions, warningsAsErrors, forceDeprecationAsWarning, showTasks, postCompileActions):
         javacArgs = ['-g', '-classpath', classPath, '-d', outputDir]
         if compliance >= '1.8':
+            """ java 9 and later uses javac to generate native headers """
+            javacArgs += ['-h', outputDir]
+        if compliance >= '1.8':
             javacArgs.append('-parameters')
         if processorPath:
             ensure_dir_exists(sourceGenDir)


### PR DESCRIPTION
Javah deprecated since jdk8 and removed in jdk11, so we have to replace it to javac -h <header_output_directory> in a build and move header generation from native build phase to java build phase.

With proposed changes mx will always generate  headers if Java class contains native method. 

