### PR TITLE
Generate native headers during java compilation

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -2613,6 +2613,9 @@ class JavacLikeCompiler(JavaCompiler):
     def prepare(self, sourceFiles, project, jdk, compliance, outputDir, classPath, processorPath, sourceGenDir,
         disableApiRestrictions, warningsAsErrors, forceDeprecationAsWarning, showTasks, postCompileActions):
         javacArgs = ['-g', '-classpath', classPath, '-d', outputDir]
+        if jdk.javaCompliance >= "9":
+            # use javac to generate native headers
+            javacArgs += ['-h', outputDir]
         if compliance >= '1.8':
             javacArgs.append('-parameters')
         if processorPath:


### PR DESCRIPTION
Javah deprecated since jdk8 and removed in jdk11, so we have to replace it to javac -h <header_output_directory> in a build and move header generation from native build phase to java build phase.

With proposed changes mx will always generate headers if Java class contains native method.