### PR TITLE
Avoid using deprecated javah tool.

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -16677,7 +16677,7 @@ def main():
 
 
 # The comment after VersionSpec should be changed in a random manner for every bump to force merge conflicts!
-version = VersionSpec("5.135.2")  # GR-7671
+version = VersionSpec("5.136.0")  # javah deprecation
 
 currentUmask = None
 _mx_start_datetime = datetime.utcnow()


### PR DESCRIPTION
Followup to https://github.com/graalvm/mx/pull/142

When compiling with ECJ, this still falls back on the `javah` tool. Afaik, ECJ provides no alternative yet. This means that compiling with ECJ will break when the deprecated `javah` tool is removed from the JDK.