### PR TITLE
Allow newer versions of pylint

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -11199,8 +11199,8 @@ def pylint(args):
             log_error('could not determine pylint version from ' + output)
             return -1
         major, minor, micro = (int(m.group(1)), int(m.group(2)), int(m.group(3)))
-        if major != 1 or minor != 1:
-            log_error('require pylint version = 1.1.x (got {0}.{1}.{2})'.format(major, minor, micro))
+        if major != 1 or minor < 1:
+            log_error('require pylint version >= 1.1.x (got {0}.{1}.{2})'.format(major, minor, micro))
             return -1
     except BaseException as e:
         log_error('pylint is not available: ' + str(e))


### PR DESCRIPTION
I don't know why the version of pylint is locked to `1.1.x`, but I'm using the latest pylint `1.8.2` without any problems. This change allows newer versions of pylint as well.