### PR TITLE
Add ability to export Jacoco reports as XML

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -15846,7 +15846,7 @@ _commands = {
     'init' : [suite_init_cmd, '[options] name'],
     'intellijinit': [intellijinit_cli, ''],
     'jackpot': [mx_jackpot.jackpot, ''],
-    'jacocoreport' : [mx_gate.jacocoreport, '[output directory]'],
+    'jacocoreport' : [mx_gate.jacocoreport, '[--format {html,xml}] [output directory]'],
     'java': [java_command, '[-options] class [args...]'],
     'javadoc': [javadoc, '[options]'],
     'javap': [javap, '[options] <class name patterns>'],

--- a/mx_gate.py
+++ b/mx_gate.py
@@ -561,11 +561,10 @@ def jacocoreport(args):
     dist = mx.distribution(dist_name)
     jdk = mx.get_jdk(dist.javaCompliance)
 
-    out = 'coverage'
-    if len(args) == 1:
-        out = args[0]
-    elif len(args) > 1:
-        mx.abort('jacocoreport takes only one argument : an output directory')
+    parser = ArgumentParser(prog='mx jacocoreport')
+    parser.add_argument('--format', help='Export format (HTML or XML)', default='html', choices=['html', 'xml'])
+    parser.add_argument('output_directory', help='Output directory', default='coverage', nargs='?')
+    args = parser.parse_args(args)
 
     # list of strings of the form "project-dir:binary-dir"
     includedirs = []
@@ -576,4 +575,4 @@ def jacocoreport(args):
                 includedirs.append(p.dir + ":" + p.classpath_repr(jdk))
 
     mx.run_java(['-cp', mx.classpath([dist_name], jdk=jdk), '-jar', dist.path,
-                 '--in', 'jacoco.exec', '--out', out] + sorted(includedirs), jdk=jdk)
+                 '--in', 'jacoco.exec', '--out', args.output_directory, '--format', args.format] + sorted(includedirs), jdk=jdk)


### PR DESCRIPTION
This allows to export Jacoco reports as XML. This way, it is possible to use coverage services like coveralls or codecov which don't seem to support the `jacoco.exec` format, but its XML format.
The new code does not change the default behavior (HTML output).

Example: `mx jacocoreport --format xml ./` generates an XML in the current directory.