### PR TITLE
Fix os.path.relpath throwing

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -15768,7 +15768,7 @@ def _intellij_suite(args, s, declared_modules, referenced_modules, sdks, refresh
         if not module_files_only:
             declared_modules.add(basename(s.mxDir))
             moduleFilePath = "$PROJECT_DIR$/" + os.path.relpath(moduleFile, s.dir)
-            modulesXml.element('module', attributes={'fileurl': 'file://$' + moduleFilePath, 'filepath': moduleFilePath})
+            modulesXml.element('module', attributes={'fileurl': 'file://' + moduleFilePath, 'filepath': moduleFilePath})
 
             declared_modules.add(basename(_mx_suite.dir))
             mxModuleFile = join(_mx_suite.dir, basename(_mx_suite.dir) + '.iml')


### PR DESCRIPTION
Replaced calls to os.path.relpath with a safe alternative, since not every path can be made relative on Windows, due to different drives.

This is based on another PR [1], where the author asked someone else to take over since they don't have time to fix the merge conflicts [2].

~I tried running `mx gate`  but that throws an unrelated error, so it doesn't look like that works on Windows yet. So be aware that this has not passed gate yet.~

[1] : https://github.com/graalvm/mx/pull/134
[2] : https://github.com/graalvm/mx/pull/134#issuecomment-436805868