### PR TITLE
Add missing has_documentation to MxCommand

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -13679,16 +13679,7 @@ Given a command name, print help for that command."""
             abort('mx: command \'{0}\' is ambiguous\n    {1}'.format(name, ' '.join(hits)))
 
     command = _mx_commands.commands()[name]
-    doc = command.command_function.__doc__
-    if command.has_documentation():
-        format_args = []
-        if command.usage_msg:
-            format_args.append(command.usage_msg)
-        if command.doc_function:
-            format_args.append(command.doc_function())
-
-        doc = doc.format(*format_args)
-    print 'mx {0} {1}\n\n{2}\n'.format(name, command.usage_msg, doc)
+    print command.get_doc()
 
 def _parse_multireleasejar_version(value):
     try:

--- a/mx_commands.py
+++ b/mx_commands.py
@@ -125,6 +125,20 @@ class MxCommand(object):
     def command_function(self):
         return self._command_function
 
+    def get_doc(self):
+        doc = 'mx {0} {1}'
+        msg = '<no documentation>'
+        if self.command_function.__doc__ or self.doc_function or self.usage_msg:
+            msg = ''
+            if self.usage_msg:
+                msg += self.usage_msg
+            if self.command_function.__doc__:
+                msg += '\n\n' + self.command_function.__doc__
+            if self.doc_function:
+                msg += '\n' + self.doc_function()
+
+        return doc.format(self.command, msg)
+
     def __call__(self, *args, **kwargs):
         for callback in self._mx_commands.command_before_callbacks:
             callback(self, *args, **kwargs)

--- a/mx_unittest.py
+++ b/mx_unittest.py
@@ -312,7 +312,6 @@ def _unittest(args, annotations, junit_args, prefixCp="", blacklist=None, whitel
             os.remove(testfile)
 
 unittestHelpSuffix = """
-
     To avoid conflicts with VM options '--' can be used as delimiter.
 
     If test filters are supplied, only tests whose fully qualified name
@@ -351,7 +350,7 @@ def is_strictly_positive(value):
 @mx.command(suite_name="mx",
             command_name='unittest',
             usage_msg='[unittest options] [--] [VM options] [filters...]',
-            doc_function=unittestHelpSuffix,
+            doc_function=lambda: unittestHelpSuffix,
             auto_add=False)
 def unittest(args):
     """run the JUnit tests"""


### PR DESCRIPTION
Running `mx help <command>` throws `'MxCommand' object has no attribute 'has_documentation'`. ~This PR adds that missing function.~

This PR:
- Replaces `has_documentation` with `get_doc`, since this simplifies usage.
- Makes sure the `unittest` command passes a doc function instead of a doc string (and removed extra newlin in doc string)
- Makes sure the `get_doc` function actually returns the documentation string.