### PR TITLE
Change mx to using print function, on the road to Python 3 support

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -29,6 +29,8 @@ r"""
 mx is a command line tool for managing the development of Java code organized as suites of projects.
 
 """
+from __future__ import print_function
+
 import sys
 from abc import ABCMeta, abstractmethod
 
@@ -358,9 +360,9 @@ def _debug_walk_deps_helper(dep, edge, ignoredEdges):
     global DEBUG_WALK_DEPS_LINE
     if DEBUG_WALK_DEPS:
         if edge:
-            print '{}:walk_deps:{}{}    # {}'.format(DEBUG_WALK_DEPS_LINE, '  ' * edge.path_len(), dep, edge.kind)
+            print('{}:walk_deps:{}{}    # {}'.format(DEBUG_WALK_DEPS_LINE, '  ' * edge.path_len(), dep, edge.kind))
         else:
-            print '{}:walk_deps:{}'.format(DEBUG_WALK_DEPS_LINE, dep)
+            print('{}:walk_deps:{}'.format(DEBUG_WALK_DEPS_LINE, dep))
         DEBUG_WALK_DEPS_LINE += 1
 
 
@@ -846,7 +848,7 @@ class BuildTask(object):
             ensure_dir_exists(dirname(savedDepsFile))
             with open(savedDepsFile, 'w') as fp:
                 for dname in currentDeps:
-                    print >> fp, dname
+                    print(dname, file=fp)
 
         return outOfDate
 
@@ -3293,7 +3295,7 @@ class JavaProject(Project, ClasspathDependency):
             ensure_dir_exists(dirname(currentApsFile))
             with open(currentApsFile, 'w') as fp:
                 for ap in aps:
-                    print >> fp, ap
+                    print(ap, file=fp)
         else:
             if exists(currentApsFile):
                 os.remove(currentApsFile)
@@ -4371,7 +4373,7 @@ def sha1(args):
     if args.plain:
         sys.stdout.write(value)
     else:
-        print 'sha1 of ' + args.path + ': ' + value
+        print('sha1 of ' + args.path + ': ' + value)
 
 
 def sha1OfFile(path):
@@ -6022,7 +6024,7 @@ class GitConfig(VC):
     def git_command(self, vcdir, args, abortOnError=False, quiet=True):
         args = ['git', '--no-pager'] + args
         if not quiet:
-            print '{0}'.format(" ".join(args))
+            print('{0}'.format(" ".join(args)))
         out = OutputCapture()
         rc = self.run(args, cwd=vcdir, nonZeroIsFatal=False, out=out)
         if rc == 0 or rc == 1:
@@ -9632,7 +9634,7 @@ class Timer():
         return self
     def __exit__(self, t, value, traceback):
         elapsed = time.time() - self.start
-        print '{} took {} seconds'.format(self.name, elapsed)
+        print('{} took {} seconds'.format(self.name, elapsed))
         return None
 
 def get_os():
@@ -10432,7 +10434,7 @@ environment variables:
                 deferrable()
 
             if opts.version:
-                print 'mx version ' + str(version)
+                print('mx version ' + str(version))
                 sys.exit(0)
 
             if opts.vm: self.unknown += ['--vm=' + opts.vm]
@@ -11190,7 +11192,7 @@ def run(args, nonZeroIsFatal=True, out=None, err=None, cwd=None, timeout=None, e
             # TODO: handle newlines in args once there's a use case
             if '\n' in arg:
                 abort('cannot handle new line in argument to run: "' + arg + '"')
-            print >> fp, arg
+            print(arg, file=fp)
     env['MX_SUBPROCESS_COMMAND_FILE'] = subprocessCommandFile
 
     if _opts.verbose:
@@ -11938,7 +11940,7 @@ def log(msg=None):
     to redirect it.
     """
     if msg is None:
-        print
+        print()
     else:
         # https://docs.python.org/2/reference/simple_stmts.html#the-print-statement
         # > A '\n' character is written at the end, unless the print statement
@@ -11953,7 +11955,7 @@ def log(msg=None):
         # instruction is omitted. By manually adding the newline to the string,
         # there is only a single PRINT_ITEM instruction which is executed
         # atomically, but still prints the newline.
-        print str(msg) + "\n",
+        print(str(msg), end='\n')
 
 # https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
 _ansi_color_table = {
@@ -11994,9 +11996,9 @@ def log_error(msg=None):
     to redirect it.
     """
     if msg is None:
-        print >> sys.stderr
+        print(sys.stderr, file=sys.stderr)
     else:
-        print >> sys.stderr, colorize(str(msg), stream=sys.stderr)
+        print(colorize(str(msg), stream=sys.stderr), file=sys.stderr)
 
 def expand_project_in_class_path_arg(cpArg, jdk=None):
     """
@@ -13275,7 +13277,7 @@ def checkoverlap(args):
                     remove.append(d)
             ds = [d for d in ds if d not in remove]
             if len(ds) > 1:
-                print '{} is in more than one distribution: {}'.format(p, [d.name for d in ds])
+                print('{} is in more than one distribution: {}'.format(p, [d.name for d in ds]))
                 count += 1
     return count
 
@@ -13702,7 +13704,7 @@ Given a command name, print help for that command."""
             abort('mx: command \'{0}\' is ambiguous\n    {1}'.format(name, ' '.join(hits)))
 
     command = _mx_commands.commands()[name]
-    print command.get_doc()
+    print(command.get_doc())
 
 def _parse_multireleasejar_version(value):
     try:
@@ -13746,11 +13748,11 @@ def flattenMultiReleaseSources(args):
         for flatten_map in maps:
             for src_dir, dst_dir in flatten_map.iteritems():
                 if not args.commands:
-                    print src_dir, dst_dir
+                    print(src_dir, dst_dir)
                 else:
                     if not exists(dst_dir):
-                        print 'mkdir -p {}'.format(dst_dir)
-                    print 'cp {}{}* {}'.format(src_dir, os.sep, dst_dir)
+                        print('mkdir -p {}'.format(dst_dir))
+                    print('cp {}{}* {}'.format(src_dir, os.sep, dst_dir))
 
 def projectgraph(args, suite=None):
     """create graph for project structure ("mx projectgraph | dot -Tpdf -oprojects.pdf" or "mx projectgraph --igv")"""
@@ -13785,15 +13787,15 @@ def projectgraph(args, suite=None):
         if attributes:
             edge_str += ' [' + ', '.join((k + '="' + v + '"' for k, v in attributes.items())) + ']'
         edge_str += ';'
-        print edge_str
+        print(edge_str)
 
-    print 'digraph projects {'
-    print 'rankdir=BT;'
-    print 'node [shape=rect];'
-    print 'splines=true;'
-    print 'ranksep=1;'
+    print('digraph projects {')
+    print('rankdir=BT;')
+    print('node [shape=rect];')
+    print('splines=true;')
+    print('ranksep=1;')
     if args.dist:
-        print 'compound=true;'
+        print('compound=true;')
         started_dists = set()
 
         used_libraries = set()
@@ -13811,7 +13813,7 @@ def projectgraph(args, suite=None):
 
         for l in used_libraries:
             if not should_ignore(l.name):
-                print '"' + l.name + '";'
+                print('"' + l.name + '";')
 
         def print_distribution(_d):
             if should_ignore(_d.name):
@@ -13820,10 +13822,10 @@ def projectgraph(args, suite=None):
                 warn("projectgraph does not support non-strictly nested distributions, result may be inaccurate around " + _d.name)
                 return
             started_dists.add(_d)
-            print 'subgraph "cluster_' + _d.name + '" {'
-            print 'label="' + _d.name + '";'
-            print 'color=blue;'
-            print '"' + _d.name + ':DUMMY" [shape=point, style=invis];'
+            print('subgraph "cluster_' + _d.name + '" {')
+            print('label="' + _d.name + '";')
+            print('color=blue;')
+            print('"' + _d.name + ':DUMMY" [shape=point, style=invis];')
 
             if _d.isDistribution():
                 overlapped_deps = set()
@@ -13834,9 +13836,9 @@ def projectgraph(args, suite=None):
                     if p.isProject() and p not in overlapped_deps:
                         if should_ignore(p.name):
                             continue
-                        print '"' + p.name + '";'
-                        print '"' + _d.name + ':DUMMY"->"' + p.name + '" [style="invis"];'
-            print '}'
+                        print('"' + p.name + '";')
+                        print('"' + _d.name + ':DUMMY"->"' + p.name + '" [style="invis"];')
+            print('}')
             for dep in _d.deps:
                 if dep.isDistribution():
                     print_edge(_d, dep)
@@ -13862,7 +13864,7 @@ def projectgraph(args, suite=None):
                 if should_ignore(apd.name):
                     continue
                 print_edge(p, apd, {"style": "dashed"})
-    print '}'
+    print('}')
 
 def _source_locator_memento(deps, jdk=None):
     slm = XMLDoc()
@@ -15229,7 +15231,7 @@ ${build.test.classes.dir}
 test.src.dir=./test
 """ + annotationProcessorSrcFolderRef + """
 source.encoding=UTF-8""".replace(':', os.pathsep).replace('/', os.sep)
-    print >> out, content
+    print(content, file=out)
 
     # Workaround for NetBeans "too clever" behavior. If you want to be
     # able to press F6 or Ctrl-F5 in NetBeans and run/debug unit tests
@@ -15239,25 +15241,25 @@ source.encoding=UTF-8""".replace(':', os.pathsep).replace('/', os.sep)
     # that will be on the class path for most Truffle projects.
     # This can be overridden by defining a netbeans.project.properties
     # attribute for a project in suite.py (see below).
-    print >> out, "main.class=com.oracle.truffle.api.impl.Accessor"
+    print("main.class=com.oracle.truffle.api.impl.Accessor", file=out)
 
     # Add extra properties specified in suite.py for this project
     if hasattr(p, 'netbeans.project.properties'):
         properties = getattr(p, 'netbeans.project.properties')
         for prop in [properties] if isinstance(properties, str) else properties:
-            print >> out, prop
+            print(prop, file=out)
 
     mainSrc = True
     for src in p.srcDirs:
         srcDir = join(p.dir, src)
         ensure_dir_exists(srcDir)
         ref = 'file.reference.' + p.name + '-' + src
-        print >> out, ref + '=' + src
+        print(ref + '=' + src, file=out)
         if mainSrc:
-            print >> out, 'src.dir=${' + ref + '}'
+            print('src.dir=${' + ref + '}', file=out)
             mainSrc = False
         else:
-            print >> out, 'src.' + src + '.dir=${' + ref + '}'
+            print('src.' + src + '.dir=${' + ref + '}', file=out)
 
     javacClasspath = []
 
@@ -15293,20 +15295,20 @@ source.encoding=UTF-8""".replace(':', os.pathsep).replace('/', os.sep)
                 if os.sep == '\\':
                     path = path.replace('\\', '\\\\')
                 ref = 'file.reference.' + dep.name + '-bin'
-                print >> out, ref + '=' + path
+                print(ref + '=' + path, file=out)
                 if libFiles:
                     libFiles.append(path)
             if sourcePath:
                 if os.sep == '\\':
                     sourcePath = sourcePath.replace('\\', '\\\\')
-                print >> out, 'source.reference.' + dep.name + '-bin=' + sourcePath
+                print('source.reference.' + dep.name + '-bin=' + sourcePath, file=out)
         elif dep.isMavenProject():
             path = dep.get_path(resolve=False)
             if path:
                 if os.sep == '\\':
                     path = path.replace('\\', '\\\\')
                 ref = 'file.reference.' + dep.name + '-bin'
-                print >> out, ref + '=' + path
+                print(ref + '=' + path, file=out)
         elif dep.isProject():
             n = dep.name.replace('.', '_')
             relDepPath = os.path.relpath(dep.dir, p.dir).replace(os.sep, '/')
@@ -15315,17 +15317,17 @@ source.encoding=UTF-8""".replace(':', os.pathsep).replace('/', os.sep)
             else:
                 depBuildPath = 'dist/' + dep.name + '.jar'
             ref = 'reference.' + n + '.jar'
-            print >> out, 'project.' + n + '=' + relDepPath
-            print >> out, ref + '=${project.' + n + '}/' + depBuildPath
+            print('project.' + n + '=' + relDepPath, file=out)
+            print(ref + '=${project.' + n + '}/' + depBuildPath, file=out)
 
         if not dep in annotationProcessorOnlyDeps:
             javacClasspath.append('${' + ref + '}')
         else:
             annotationProcessorReferences.append('${' + ref + '}')
 
-    print >> out, 'javac.classpath=\\\n    ' + (os.pathsep + '\\\n    ').join(javacClasspath)
-    print >> out, 'javac.processorpath=' + (os.pathsep + '\\\n    ').join(['${javac.classpath}'] + annotationProcessorReferences)
-    print >> out, 'javac.test.processorpath=' + (os.pathsep + '\\\n    ').join(['${javac.test.classpath}'] + annotationProcessorReferences)
+    print('javac.classpath=\\\n    ' + (os.pathsep + '\\\n    ').join(javacClasspath), file=out)
+    print('javac.processorpath=' + (os.pathsep + '\\\n    ').join(['${javac.classpath}'] + annotationProcessorReferences), file=out)
+    print('javac.test.processorpath=' + (os.pathsep + '\\\n    ').join(['${javac.test.classpath}'] + annotationProcessorReferences), file=out)
 
     update_file(join(p.dir, 'nbproject', 'project.properties'), out.getvalue())
     out.close()
@@ -15963,27 +15965,27 @@ def _intellij_suite(args, s, declared_modules, referenced_modules, sdks, refresh
                 miscXml = XMLDoc()
                 miscXml.open('project', attributes={'version' : '4'})
                 out = StringIO.StringIO()
-                print >> out, '# GENERATED -- DO NOT EDIT'
+                print('# GENERATED -- DO NOT EDIT', file=out)
                 for source in corePrefsSources:
-                    print >> out, '# Source:', source
+                    print('# Source:', source, file=out)
                     with open(source) as fileName:
                         for line in fileName:
                             if line.startswith('org.eclipse.jdt.core.formatter.'):
-                                print >> out, line.strip()
+                                print(line.strip(), file=out)
                 formatterConfigFile = join(ideaProjectDirectory, 'EclipseCodeFormatter.prefs')
                 update_file(formatterConfigFile, out.getvalue())
                 importConfigFile = None
                 if uiPrefsSources:
                     out = StringIO.StringIO()
-                    print >> out, '# GENERATED -- DO NOT EDIT'
+                    print('# GENERATED -- DO NOT EDIT', file=out)
                     for source in uiPrefsSources:
-                        print >> out, '# Source:', source
+                        print('# Source:', source, file=out)
                         with open(source) as fileName:
                             for line in fileName:
                                 if line.startswith('org.eclipse.jdt.ui.importorder') \
                                         or line.startswith('org.eclipse.jdt.ui.ondemandthreshold') \
                                         or line.startswith('org.eclipse.jdt.ui.staticondemandthreshold'):
-                                    print >> out, line.strip()
+                                    print(line.strip(), file=out)
                     importConfigFile = join(ideaProjectDirectory, 'EclipseImports.prefs')
                     update_file(importConfigFile, out.getvalue())
                 miscXml.open('component', attributes={'name' : 'EclipseCodeFormatterProjectSettings'})
@@ -16546,7 +16548,7 @@ def javadoc(args, parser=None, docDir='javadoc', includeDeps=True, stdDoclet=Tru
             delOverviewFile = False
             if not exists(overviewFile):
                 with open(overviewFile, 'w') as fp:
-                    print >> fp, '<html><body>Documentation for the <code>' + p.name + '</code> project.</body></html>'
+                    print('<html><body>Documentation for the <code>' + p.name + '</code> project.</body></html>', file=fp)
                 delOverviewFile = True
             nowarnAPI = []
             if not args.warnAPI:
@@ -16775,19 +16777,19 @@ def site(args):
             if idx != -1:
                 args.overview = join(tmpbase, 'overview_with_projects.html')
                 with open(args.overview, 'w') as fp2:
-                    print >> fp2, content[0:idx]
-                    print >> fp2, """<div class="contentContainer">
+                    print(content[0:idx], file=fp2)
+                    print("""<div class="contentContainer">, file=fp2
 <table class="overviewSummary" border="0" cellpadding="3" cellspacing="0" summary="Projects table">
 <caption><span>Projects</span><span class="tabEnd">&nbsp;</span></caption>
 <tr><th class="colFirst" scope="col">Project</th><th class="colLast" scope="col">&nbsp;</th></tr>
-<tbody>"""
+<tbody>""")
                     color = 'row'
                     for p in projects:
-                        print >> fp2, '<tr class="{1}Color"><td class="colFirst"><a href="../{0}/javadoc/index.html",target = "_top">{0}</a></td><td class="colLast">&nbsp;</td></tr>'.format(p.name, color)
+                        print('<tr class="{1}Color"><td class="colFirst"><a href="../{0}/javadoc/index.html",target = "_top">{0}</a></td><td class="colLast">&nbsp;</td></tr>'.format(p.name, color), file=fp2)
                         color = 'row' if color == 'alt' else 'alt'
 
-                    print >> fp2, '</tbody></table></div>'
-                    print >> fp2, content[idx:]
+                    print('</tbody></table></div>', file=fp2)
+                    print(content[idx:], file=fp2)
 
         title = args.title if args.title is not None else args.name
         javadoc(['--base', tmpbase,
@@ -16820,21 +16822,21 @@ def site(args):
             html = join(tmpbase, 'all', str(args.dot_output_base) + '.html')
             with open(dot, 'w') as fp:
                 dim = len(projects)
-                print >> fp, 'digraph projects {'
-                print >> fp, 'rankdir=BT;'
-                print >> fp, 'size = "' + str(dim) + ',' + str(dim) + '";'
-                print >> fp, 'node [shape=rect, fontcolor="blue"];'
-                # print >> fp, 'edge [color="green"];'
+                print('digraph projects {', file=fp)
+                print('rankdir=BT;', file=fp)
+                print('size = "' + str(dim) + ',' + str(dim) + '";', file=fp)
+                print('node [shape=rect, fontcolor="blue"];', file=fp)
+                # print('edge [color="green"];', file=fp)
                 for p in projects:
-                    print >> fp, '"' + p.name + '" [URL = "../' + p.name + '/javadoc/index.html", target = "_top"]'
+                    print('"' + p.name + '" [URL = "../' + p.name + '/javadoc/index.html", target = "_top"]', file=fp)
                     for dep in p.canonical_deps():
                         if dep in [proj.name for proj in projects]:
-                            print >> fp, '"' + p.name + '" -> "' + dep + '"'
+                            print('"' + p.name + '" -> "' + dep + '"', file=fp)
                 depths = dict()
                 for p in projects:
                     d = p.max_depth()
                     depths.setdefault(d, list()).append(p.name)
-                print >> fp, '}'
+                print('}', file=fp)
 
             run(['dot', '-Tsvg', '-o' + svg, '-Tjpg', '-o' + jpg, dot])
 
@@ -16849,7 +16851,7 @@ def site(args):
 
             # Create HTML that embeds the svg file in an <object> frame
             with open(html, 'w') as fp:
-                print >> fp, '<html><body><object data="{0}.svg" type="image/svg+xml"></object></body></html>'.format(args.dot_output_base)
+                print('<html><body><object data="{0}.svg" type="image/svg+xml"></object></body></html>'.format(args.dot_output_base), file=fp)
 
 
         if args.tmp:
@@ -16857,7 +16859,7 @@ def site(args):
         else:
             shutil.move(tmpbase, args.base)
 
-        print 'Created website - root is ' + join(args.base, 'all', 'index.html')
+        print('Created website - root is ' + join(args.base, 'all', 'index.html'))
 
     finally:
         if not args.tmp and exists(tmpbase):
@@ -17009,7 +17011,7 @@ def _scheck_imports(importing_suite, imported_suite, suite_import, bookmark_impo
             msg = '{}\nIf the only uncommitted change is an updated imported suite version, then you can run:\n\nhg -R {} commit -m "updated imported suite version"'.format(msg, imported_suite.vc_dir)
         abort(msg)
     if importedVersion != suite_import.version and suite_import.version is not None:
-        print 'imported version of {} in {} ({}) does not match parent ({})'.format(imported_suite.name, importing_suite.name, suite_import.version, importedVersion)
+        print('imported version of {} in {} ({}) does not match parent ({})'.format(imported_suite.name, importing_suite.name, suite_import.version, importedVersion))
         if exists(importing_suite.suite_py()) and ask_yes_no('Update ' + importing_suite.suite_py()):
             with open(importing_suite.suite_py()) as fp:
                 contents = fp.read()
@@ -17021,7 +17023,7 @@ def _scheck_imports(importing_suite, imported_suite, suite_import, bookmark_impo
                 if bookmark_imports:
                     _sbookmark_visitor(importing_suite, suite_import)
             else:
-                print 'Could not update as the substring {} does not appear exactly once in {}'.format(suite_import.version, importing_suite.suite_py())
+                print('Could not update as the substring {} does not appear exactly once in {}'.format(suite_import.version, importing_suite.suite_py()))
 
 
 @no_suite_loading
@@ -17115,7 +17117,7 @@ def _sincoming(s, suite_import):
 
     output = s.vc.incoming(s.vc_dir)
     if output:
-        print output
+        print(output)
 
 
 @no_suite_loading
@@ -17138,7 +17140,7 @@ def _hg_command(s, suite_import, **extra_args):
 
     if isinstance(s.vc, HgConfig):
         out = s.vc.hg_command(s.vc_dir, extra_args['args'])
-        print out
+        print(out)
 
 
 @no_suite_loading
@@ -17156,7 +17158,7 @@ def _stip_import_visitor(s, suite_import, **extra_args):
 def _stip(s, suite_import):
     s.visit_imports(_stip_import_visitor)
 
-    print 'tip of ' + s.name + ': ' + s.vc.tip(s.vc_dir)
+    print('tip of ' + s.name + ': ' + s.vc.tip(s.vc_dir))
 
 
 @no_suite_loading
@@ -17195,9 +17197,9 @@ def sversions(args):
             return
         visited.add(s.dir)
         if s.vc == None:
-            print 'No version control info for suite ' + s.name
+            print('No version control info for suite ' + s.name)
         else:
-            print _sversions_rev(s.vc.parent(s.vc_dir), s.vc.isDirty(s.vc_dir), with_color) + ' ' + s.name + ' ' + s.vc_dir
+            print(_sversions_rev(s.vc.parent(s.vc_dir), s.vc.isDirty(s.vc_dir), with_color) + ' ' + s.name + ' ' + s.vc_dir)
         s.visit_imports(_sversions_import_visitor)
 
     if not isinstance(primary_suite(), MXSuite):
@@ -17367,7 +17369,7 @@ def exportlibs(args):
                         break
                     d.update(buf)
             with open(path + '.' + suffix, 'w') as fp:
-                print >> fp, d.hexdigest()
+                print(d.hexdigest(), file=fp)
             log('created ' + path + '.' + suffix)
 
     digest(args.sha1, path, hashlib.sha1, 'sha1')
@@ -17726,17 +17728,17 @@ def maven_install(args):
         if nolocalchanges:
             mvn_local_install(_mavenGroupId(s.name), _map_to_maven_dist_name(mxMetaName), mxMetaJar, version, args.repo)
         else:
-            print 'Local changes found, skipping install of ' + version + ' version'
+            print('Local changes found, skipping install of ' + version + ' version')
         mvn_local_install(_mavenGroupId(s.name), _map_to_maven_dist_name(mxMetaName), mxMetaJar, releaseVersion, args.repo)
         for dist in arcdists:
             if nolocalchanges:
                 mvn_local_install(dist.maven_group_id(), dist.maven_artifact_id(), dist.path, version, args.repo)
             mvn_local_install(dist.maven_group_id(), dist.maven_artifact_id(), dist.path, releaseVersion, args.repo)
     else:
-        print 'jars to deploy manually for version: ' + version
-        print 'name: ' + _map_to_maven_dist_name(mxMetaName) + ', path: ' + os.path.relpath(mxMetaJar, s.dir)
+        print('jars to deploy manually for version: ' + version)
+        print('name: ' + _map_to_maven_dist_name(mxMetaName) + ', path: ' + os.path.relpath(mxMetaJar, s.dir))
         for dist in arcdists:
-            print 'name: ' + dist.maven_artifact_id() + ', path: ' + os.path.relpath(dist.path, s.dir)
+            print('name: ' + dist.maven_artifact_id() + ', path: ' + os.path.relpath(dist.path, s.dir))
 
 def _copy_eclipse_settings(p, files=None):
     processors = p.annotation_processors()
@@ -17746,11 +17748,11 @@ def _copy_eclipse_settings(p, files=None):
 
     for name, sources in p.eclipse_settings_sources().iteritems():
         out = StringIO.StringIO()
-        print >> out, '# GENERATED -- DO NOT EDIT'
+        print('# GENERATED -- DO NOT EDIT', file=out)
         for source in sources:
-            print >> out, '# Source:', source
+            print('# Source:', source, file=out)
             with open(source) as f:
-                print >> out, f.read()
+                print(f.read(), file=out)
         if p.javaCompliance:
             jc = p.javaCompliance if p.javaCompliance.value < _max_Eclipse_JavaExecutionEnvironment else JavaCompliance(_max_Eclipse_JavaExecutionEnvironment)
             content = out.getvalue().replace('${javaCompliance}', str(jc))
@@ -17832,7 +17834,7 @@ def show_envs(args):
 
     for key, value in os.environ.iteritems():
         if args.all or key.startswith('MX'):
-            print '{0}: {1}'.format(key, value)
+            print('{0}: {1}'.format(key, value))
 
 def show_version(args):
     """print mx version"""
@@ -17843,12 +17845,12 @@ def show_version(args):
     if args.oneline:
         vc = VC.get_vc(_mx_home, abortOnError=False)
         if vc == None:
-            print 'No version control info for mx %s' % version
+            print('No version control info for mx %s' % version)
         else:
-            print _sversions_rev(vc.parent(_mx_home), vc.isDirty(_mx_home), False) + ' mx %s' % version
+            print(_sversions_rev(vc.parent(_mx_home), vc.isDirty(_mx_home), False) + ' mx %s' % version)
         return
 
-    print version
+    print(version)
 
 @suite_context_free
 def update(args):
@@ -17860,11 +17862,11 @@ def update(args):
     vc = VC.get_vc(_mx_home, abortOnError=False)
     if isinstance(vc, GitConfig):
         if args.dry_run:
-            print vc.incoming(_mx_home)
+            print(vc.incoming(_mx_home))
         else:
-            print vc.pull(_mx_home, update=True)
+            print(vc.pull(_mx_home, update=True))
     else:
-        print 'Cannot update mx as git is unavailable'
+        print('Cannot update mx as git is unavailable')
 
 def remove_doubledash(args):
     if '--' in args:
@@ -17878,7 +17880,7 @@ def ask_question(question, options, default=None, answer=None):
         questionMark = questionMark.replace(default, default.upper())
     if answer:
         answer = str(answer)
-        print question + questionMark + answer
+        print(question + questionMark + answer)
     else:
         if is_interactive():
             answer = raw_input(question + questionMark) or default
@@ -17913,20 +17915,20 @@ def warn(msg, context=None):
             else:
                 contextMsg = str(context)
             msg = contextMsg + ":\n" + msg
-        print >> sys.stderr, colorize('WARNING: ' + msg, color='magenta', bright=True, stream=sys.stderr)
+        print(colorize('WARNING: ' + msg, color='magenta', bright=True, stream=sys.stderr), file=sys.stderr)
 
 def print_simple_help():
-    print 'Welcome to Mx version ' + str(version)
-    print ArgumentParser.format_help(_argParser)
-    print 'Modify mx.<suite>/suite.py in the top level directory of a suite to change the project structure'
-    print 'Here are common Mx commands:'
-    print '\nBuilding and testing:'
-    print list_commands(_build_commands)
-    print 'Checking stylistic aspects:'
-    print list_commands(_style_check_commands)
-    print 'Useful utilities:'
-    print list_commands(_utilities_commands)
-    print '\'mx help\' lists all commands. See \'mx help <command>\' to read about a specific command'
+    print('Welcome to Mx version ' + str(version))
+    print(ArgumentParser.format_help(_argParser))
+    print('Modify mx.<suite>/suite.py in the top level directory of a suite to change the project structure')
+    print('Here are common Mx commands:')
+    print('\nBuilding and testing:')
+    print(list_commands(_build_commands))
+    print('Checking stylistic aspects:')
+    print(list_commands(_style_check_commands))
+    print('Useful utilities:')
+    print(list_commands(_utilities_commands))
+    print('\'mx help\' lists all commands. See \'mx help <command>\' to read about a specific command')
 
 
 def list_commands(l):

--- a/mx_benchmark.py
+++ b/mx_benchmark.py
@@ -24,6 +24,8 @@
 #
 # ----------------------------------------------------------------------------------------------------
 
+from __future__ import print_function
+
 import json
 import os.path
 import platform
@@ -1796,11 +1798,11 @@ class BenchmarkExecutor(object):
 
         if mxBenchmarkArgs.list:
             if mxBenchmarkArgs.benchmark and suite:
-                print "The following benchmarks are available in suite {}:\n".format(suite.name())
+                print("The following benchmarks are available in suite {}:\n".format(suite.name()))
                 for name in suite.benchmarkList(bmSuiteArgs):
-                    print "  " + name
+                    print("  " + name)
                 if isinstance(suite.get_vm_registry(), VmBenchmarkSuite):
-                    print "\n{}".format(suite.get_vm_registry().get_available_vm_configs_help())
+                    print("\n{}".format(suite.get_vm_registry().get_available_vm_configs_help()))
             else:
                 vmregToSuites = {}
                 noVmRegSuites = []
@@ -1811,24 +1813,24 @@ class BenchmarkExecutor(object):
                     else:
                         noVmRegSuites.append(bm_suite_name)
                 for vmreg, bm_suite_names in vmregToSuites.iteritems():
-                    print "\nThe following {} benchmark suites are available:\n".format(vmreg.vm_type_name)
+                    print("\nThe following {} benchmark suites are available:\n".format(vmreg.vm_type_name))
                     for name in bm_suite_names:
-                        print "  " + name
-                    print "\n{}".format(vmreg.get_available_vm_configs_help())
+                        print("  " + name)
+                    print("\n{}".format(vmreg.get_available_vm_configs_help()))
                 if noVmRegSuites:
-                    print "\nThe following non-VM benchmark suites are available:\n"
+                    print("\nThe following non-VM benchmark suites are available:\n")
                     for name in noVmRegSuites:
-                        print "  " + name
+                        print("  " + name)
             return 0
 
         if mxBenchmarkArgs.help or mxBenchmarkArgs.benchmark is None:
             parser.print_help()
             for key, entry in parsers.iteritems():
                 if mxBenchmarkArgs.benchmark is None or key in suite.parserNames():
-                    print entry.description
+                    print(entry.description)
                     entry.parser.print_help()
             for vmreg in vm_registries():
-                print "\n{}".format(vmreg.get_available_vm_configs_help())
+                print("\n{}".format(vmreg.get_available_vm_configs_help()))
             return 0 if mxBenchmarkArgs.help else 1
 
         self.checkEnvironmentVars()

--- a/mx_benchplot.py
+++ b/mx_benchplot.py
@@ -24,6 +24,8 @@
 #
 # ----------------------------------------------------------------------------------------------------
 
+from __future__ import print_function
+
 import json
 from argparse import ArgumentParser, REMAINDER
 from argparse import RawTextHelpFormatter
@@ -319,7 +321,7 @@ Otherwise the names are derived from the filenames.""", type=lambda s: s.split('
             plt.show()
 
     except ImportError as e:
-        print e
+        print(e)
         mx.abort('matplotlib must be available to use benchplot.  Install it using pip')
 
 

--- a/mx_compat.py
+++ b/mx_compat.py
@@ -24,6 +24,8 @@
 #
 # ----------------------------------------------------------------------------------------------------
 
+from __future__ import print_function
+
 import sys, inspect, re, types, bisect
 from collections import OrderedDict
 from os.path import join

--- a/mx_findbugs.py
+++ b/mx_findbugs.py
@@ -26,6 +26,8 @@
 # ----------------------------------------------------------------------------------------------------
 #
 
+from __future__ import print_function
+
 import mx
 import os
 import tempfile
@@ -112,7 +114,7 @@ def findbugs(args, fbArgs=None, suite=None, projects=None):
             xmlDoc.close('Match')
         xmlDoc.close('FindBugsFilter')
         xml = xmlDoc.xml(indent='  ', newl='\n')
-        print >> fp, xml
+        print(xml, file=fp)
 
     outputDirs = map(mx._cygpathU2W, [p.output_dir() for p in projectsToTest])
     javaCompliance = max([p.javaCompliance for p in projectsToTest])

--- a/mx_javamodules.py
+++ b/mx_javamodules.py
@@ -24,6 +24,8 @@
 #
 # ----------------------------------------------------------------------------------------------------
 
+from __future__ import print_function
+
 import os
 import re
 import zipfile
@@ -144,30 +146,30 @@ class JavaModuleDescriptor(object):
         Gets this module descriptor expressed as the contents of a ``module-info.java`` file.
         """
         out = StringIO.StringIO()
-        print >> out, 'module ' + self.name + ' {'
+        print('module ' + self.name + ' {', file=out)
         for dependency, modifiers in sorted(self.requires.iteritems()):
             modifiers_string = (' '.join(sorted(modifiers)) + ' ') if len(modifiers) != 0 else ''
-            print >> out, '    requires ' + modifiers_string + dependency + ';'
+            print('    requires ' + modifiers_string + dependency + ';', file=out)
         for source, targets in sorted(self.exports.iteritems()):
             targets_string = (' to ' + ', '.join(sorted(targets))) if len(targets) != 0 else ''
-            print >> out, '    exports ' + source + targets_string + ';'
+            print('    exports ' + source + targets_string + ';', file=out)
         for use in sorted(self.uses):
-            print >> out, '    uses ' + use + ';'
+            print('    uses ' + use + ';', file=out)
         for service, providers in sorted(self.provides.iteritems()):
-            print >> out, '    provides ' + service + ' with ' + ', '.join((p for p in providers)) + ';'
+            print('    provides ' + service + ' with ' + ', '.join((p for p in providers)) + ';', file=out)
         for pkg in sorted(self.conceals):
-            print >> out, '    // conceals: ' + pkg
+            print('    // conceals: ' + pkg, file=out)
         if self.jarpath:
-            print >> out, '    // jarpath: ' + self.jarpath
+            print('    // jarpath: ' + self.jarpath, file=out)
         if self.dist:
-            print >> out, '    // dist: ' + self.dist.name
+            print('    // dist: ' + self.dist.name, file=out)
         if self.modulepath:
-            print >> out, '    // modulepath: ' + ', '.join([jmd.name for jmd in self.modulepath])
+            print('    // modulepath: ' + ', '.join([jmd.name for jmd in self.modulepath]), file=out)
         if self.concealedRequires:
             for dependency, packages in sorted(self.concealedRequires.iteritems()):
                 for package in sorted(packages):
-                    print >> out, '    // concealed-requires: ' + dependency + '/' + package
-        print >> out, '}'
+                    print('    // concealed-requires: ' + dependency + '/' + package, file=out)
+        print('}', file=out)
         return out.getvalue()
 
 def lookup_package(modulepath, package, importer):
@@ -587,7 +589,7 @@ def make_java_module(dist, jdk):
             # Compile module-info.class
             module_info_java = join(dest_dir, 'module-info.java')
             with open(module_info_java, 'w') as fp:
-                print >> fp, jmd.as_module_info()
+                print(jmd.as_module_info(), file=fp)
             javacCmd = [jdk.javac, '-d', dest_dir]
             jdkModuleNames = [m.name for m in jdkModules]
             modulepathJars = [m.jarpath for m in jmd.modulepath if m.jarpath and m.name not in jdkModuleNames]

--- a/mx_sigtest.py
+++ b/mx_sigtest.py
@@ -26,6 +26,8 @@
 # ----------------------------------------------------------------------------------------------------
 #
 
+from __future__ import print_function
+
 import mx
 import os
 from os.path import exists
@@ -111,7 +113,7 @@ def _sigtest_check(checktype, args, suite=None, projects=None):
         for pkg in mx._find_packages(p):
             cmd = cmd + ['-PackageWithoutSubpackages', pkg]
         out = OutputCapture()
-        print 'Checking ' + checktype + ' signature changes against ' + sigtestResults
+        print('Checking ' + checktype + ' signature changes against ' + sigtestResults)
         exitcode = mx.run_java(cmd, nonZeroIsFatal=False, jdk=mx.get_jdk(javaCompliance), out=out, err=out)
         mx.ensure_dir_exists(p.get_output_root())
         with open(p.get_output_root() + os.path.sep + 'sigtest-junit.xml', 'w') as f:
@@ -119,7 +121,7 @@ def _sigtest_check(checktype, args, suite=None, projects=None):
             f.write('<testsuite tests="1" name="' + p.name + '.sigtest.' + checktype + '">\n')
             f.write('<testcase classname="' + p.name + '" name="sigtest.' + checktype + '">\n')
             if exitcode != 95:
-                print out.data
+                print(out.data)
                 failed = sigtestResults
                 f.write('<failure type="SignatureCheck"><![CDATA[\n')
                 f.write(out.data)
@@ -133,5 +135,5 @@ def _sigtest_check(checktype, args, suite=None, projects=None):
     if failed:
         mx.abort('Signature error in ' + failed)
     else:
-        print 'OK.'
+        print('OK.')
     return 0

--- a/mx_unittest.py
+++ b/mx_unittest.py
@@ -26,6 +26,8 @@
 # ----------------------------------------------------------------------------------------------------
 #
 
+from __future__ import print_function
+
 import mx
 import os
 import re
@@ -70,12 +72,12 @@ def _write_cached_testclasses(cachesDir, jar, jdk, testclasses, excludedclasses)
     try:
         with open(cache, 'w') as fp:
             for classname in testclasses:
-                print >> fp, classname
+                print(classname, file=fp)
         with open(exclusions, 'w') as fp:
             if excludedclasses:
                 mx.warn('Unsupported class files listed in ' + exclusions)
             for classname in excludedclasses:
-                print >> fp, classname[1:]
+                print(classname[1:], file=fp)
     except IOError as e:
         mx.warn('Error writing to ' + cache + ': ' + str(e))
 

--- a/mx_urlrewrites.py
+++ b/mx_urlrewrites.py
@@ -24,6 +24,8 @@
 #
 # ----------------------------------------------------------------------------------------------------
 
+from __future__ import print_function
+
 import re
 import json
 import mx
@@ -127,7 +129,7 @@ def rewriteurl(url):
 def urlrewrite_cli(args):
     """rewrites the given URL using MX_URLREWRITES"""
     assert len(args) == 1
-    print rewriteurl(args[0])
+    print(rewriteurl(args[0]))
 
 class URLRewrite(object):
     """

--- a/select_jdk.py
+++ b/select_jdk.py
@@ -24,6 +24,8 @@
 #
 # ----------------------------------------------------------------------------------------------------
 
+from __future__ import print_function
+
 import os, tempfile
 from argparse import ArgumentParser, REMAINDER
 from os.path import exists, expanduser, join, isdir, isfile, realpath, dirname, abspath
@@ -86,9 +88,9 @@ def get_PATH_sep(shell):
 def get_shell_commands(args, jdk, extra_jdks):
     setvar_format = get_setvar_format(args.shell)
     shell_commands = StringIO.StringIO()
-    print >> shell_commands, setvar_format % ('JAVA_HOME', jdk)
+    print(setvar_format % ('JAVA_HOME', jdk), file=shell_commands)
     if extra_jdks:
-        print >> shell_commands, setvar_format % ('EXTRA_JAVA_HOMES', os.pathsep.join(extra_jdks))
+        print(setvar_format % ('EXTRA_JAVA_HOMES', os.pathsep.join(extra_jdks)), file=shell_commands)
     path = os.environ.get('PATH').split(os.pathsep)
     if path:
         jdk_bin = join(jdk, 'bin')
@@ -98,30 +100,30 @@ def get_shell_commands(args, jdk, extra_jdks):
             path = [e if e != replace else jdk_bin for e in path]
         else:
             path.append(jdk_bin)
-        print >> shell_commands, setvar_format % ('PATH', get_PATH_sep(args.shell).join(path))
+        print(setvar_format % ('PATH', get_PATH_sep(args.shell).join(path)), file=shell_commands)
     return shell_commands.getvalue().strip()
 
 def apply_selection(args, jdk, extra_jdks):
-    print 'JAVA_HOME=' + jdk
+    print('JAVA_HOME=' + jdk)
     if extra_jdks:
-        print 'EXTRA_JAVA_HOMES=' + os.pathsep.join(extra_jdks)
+        print('EXTRA_JAVA_HOMES=' + os.pathsep.join(extra_jdks))
 
     if args.shell_file:
         with open(args.shell_file, 'w') as fp:
-            print >> fp, get_shell_commands(args, jdk, extra_jdks)
+            print(get_shell_commands(args, jdk, extra_jdks), file=fp)
     else:
         env = get_suite_env_file(args.suite_path)
         if env:
             with open(env, 'a') as fp:
-                print >> fp, 'JAVA_HOME=' + jdk
+                print('JAVA_HOME=' + jdk, file=fp)
                 if extra_jdks:
-                    print >> fp, 'EXTRA_JAVA_HOMES=' + os.pathsep.join(extra_jdks)
-            print 'Updated', env
+                    print('EXTRA_JAVA_HOMES=' + os.pathsep.join(extra_jdks), file=fp)
+            print('Updated', env)
         else:
-            print
-            print 'To apply the above environment variable settings, eval the following in your shell:'
-            print
-            print get_shell_commands(args, jdk, extra_jdks)
+            print()
+            print('To apply the above environment variable settings, eval the following in your shell:')
+            print()
+            print(get_shell_commands(args, jdk, extra_jdks))
 
 if __name__ == '__main__':
     parser = ArgumentParser(prog='select_jdk', usage='%(prog)s [options] [<primary jdk> [<secondary jdk>...]]' + """
@@ -181,7 +183,7 @@ if __name__ == '__main__':
             raise SystemExit('Following JDKs appear to be invalid (java executable not found):\n' + '\n'.join(invalid_jdks))
         with open(jdk_cache_path, 'a') as fp:
             for jdk in args.jdks:
-                print >> fp, jdk
+                print(jdk, file=fp)
         apply_selection(args, args.jdks[0], args.jdks[1:])
     else:
         jdks = find_system_jdks()
@@ -190,20 +192,20 @@ if __name__ == '__main__':
                 jdks.update((line.strip() for line in fp.readlines() if is_valid_jdk(line.strip())))
 
         sorted_jdks = sorted(jdks)
-        print "Current JDK Settings:"
+        print("Current JDK Settings:")
         for name in ['JAVA_HOME', 'EXTRA_JAVA_HOMES']:
             jdk = os.environ.get(name, None)
             if jdk:
                 if jdk in sorted_jdks:
                     jdk = '{} [{}]'.format(jdk, sorted_jdks.index(jdk))
-                print '{}={}'.format(name, jdk)
+                print('{}={}'.format(name, jdk))
         choices = list(enumerate(sorted_jdks))
         if choices:
             _, tmp_cache_path = tempfile.mkstemp(dir=dirname(jdk_cache_path))
             with open(tmp_cache_path, 'w') as fp:
                 for index, jdk in choices:
-                    print '[{}] {}'.format(index, jdk)
-                    print >> fp, jdk
+                    print('[{}] {}'.format(index, jdk))
+                    print(jdk, file=fp)
 
             os.rename(tmp_cache_path, jdk_cache_path)
             choices = {str(index):jdk for index, jdk in choices}

--- a/tag_version.py
+++ b/tag_version.py
@@ -25,6 +25,9 @@
 #
 # ----------------------------------------------------------------------------------------------------
 #
+
+from __future__ import print_function
+
 import subprocess, re
 from argparse import ArgumentParser
 from os.path import realpath, dirname
@@ -85,7 +88,7 @@ def version_to_ints(spec):
 if new_version and old_version:
     tag = new_version.group(1)
     old_tag = old_version.group(1)
-    print 'Found update of mx version from {} to {}'.format(old_tag, tag)
+    print('Found update of mx version from {} to {}'.format(old_tag, tag))
     old = version_to_ints(old_tag)
     new = version_to_ints(tag)
     if old >= new:

--- a/tests/mx.mxtests/mx_mxtests.py
+++ b/tests/mx.mxtests/mx_mxtests.py
@@ -1,6 +1,8 @@
 # A collections of commands that exercise some mx functions in the context of a particular set of suites.
 # Incomplete
 
+from __future__ import print_function
+
 from argparse import ArgumentParser
 import os
 import urllib
@@ -18,10 +20,10 @@ def _cp(args):
     parser.add_argument('--ignoreSelf', action='store_true', help='ignoreSelf')
     args = parser.parse_args(args)
     result = mx.classpath(args.project, resolve=not args.noResolve, includeSelf=not args.ignoreSelf)
-    print 'classpath for: ', args.project
+    print('classpath for: ', args.project)
     comps = result.split(':')
     for comp in comps:
-        print comp
+        print(comp)
 
 def _ap(args):
     parser = ArgumentParser(prog='mx mxt-proj-ap-path')
@@ -29,10 +31,10 @@ def _ap(args):
     args = parser.parse_args(args)
     project = mx.project(args.project)
     result = project.annotation_processors_path()
-    print 'annotation_processors_path for: ', args.project
+    print('annotation_processors_path for: ', args.project)
     comps = result.split(':')
     for comp in comps:
-        print comp
+        print(comp)
 
 def _alldeps(args):
     parser = ArgumentParser(prog='mx mxt-alldeps')
@@ -53,9 +55,9 @@ def _alldeps(args):
 
     in_deps = []
     deps = entity.all_deps(in_deps, includeLibs=args.includeLibs, includeSelf=not args.ignoreSelf)
-    print 'alldeps:'
+    print('alldeps:')
     for d in deps:
-        print d.__class__.__name__, ":", d.name
+        print(d.__class__.__name__, ":", d.name)
 
 from HTMLParser import HTMLParser
 
@@ -63,11 +65,11 @@ class MyHTMLParser(HTMLParser):
     def __init__(self):
         HTMLParser.__init__(self)
     def handle_starttag(self, tag, attrs):
-        print "Start tag:", tag
+        print("Start tag:", tag)
         for attr in attrs:
-            print "     attr:", attr
+            print("     attr:", attr)
     def handle_endtag(self, tag):
-        print "End tag  :", tag
+        print("End tag  :", tag)
 
 class DirHTMLParser(HTMLParser):
     def __init__(self):
@@ -88,7 +90,7 @@ def _readurl(args):
     args = parser.parse_args(args)
     if 'file://' in args.url:
         for f in os.listdir(args.url.replace('file://', '')):
-            print f
+            print(f)
     else:
         f = urllib.urlopen(args.url)
         text = f.read()
@@ -96,7 +98,7 @@ def _readurl(args):
         parser.feed(text)
         if not args.print_tags:
             for f in parser.files:
-                print f
+                print(f)
 
 def _vc_clone(args):
     parser = ArgumentParser(prog='mx mxt-vc-clone')
@@ -108,7 +110,7 @@ def _vc_clone(args):
     args = parser.parse_args(args)
     vc = mx.vc_system(args.kind)
     rc = vc.clone(args.url, args.target, args.rev, args.log == 'True')
-    print rc
+    print(rc)
 
 def _vc_pull(args):
     parser = ArgumentParser(prog='mx mxt-vc-pull')
@@ -126,7 +128,7 @@ def _vc_tip(args):
     args = parser.parse_args(args)
     vc = mx.vc_system(args.kind)
     rc = vc.tip(args.dir)
-    print rc
+    print(rc)
 
 def _vc_locate(args):
     parser = ArgumentParser(prog='mx mxt-vc-locate')
@@ -137,7 +139,7 @@ def _vc_locate(args):
     vc = mx.vc_system(args.kind)
     lines = vc.locate(args.dir, patterns=args.patterns)
     for line in lines:
-        print line
+        print(line)
 
 def _command_info(args):
     parser = ArgumentParser(prog='mx mxt-command_function')


### PR DESCRIPTION
In a move towards supporting python 3, I have changed all print statements in the `mx` repo to the `print` function using the `__future__` import.

The print statement is not syntactically compatible with python 3, but the print function is.

See also: https://github.com/graalvm/mx/issues/168