### PR TITLE
Switch hard coded path separators to relying on `join()`

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -3059,10 +3059,10 @@ class JavaProject(Project, ClasspathDependency):
         if configZip.isOlderThan(join(self.dir, 'build.xml')):
             return False
 
-        if configZip.isOlderThan(join(self.dir, 'nbproject/project.xml')):
+        if configZip.isOlderThan(join(self.dir, 'nbproject', 'project.xml')):
             return False
 
-        if configZip.isOlderThan(join(self.dir, 'nbproject/project.properties')):
+        if configZip.isOlderThan(join(self.dir, 'nbproject', 'project.properties')):
             return False
 
         return True


### PR DESCRIPTION
A recent change uses a hardcoded unix path separator in a path. This is throwing the following error on windows when running `mx ideinit` in the mx suite:

```
Traceback (most recent call last):
  File "J:\Projects\mx2\mx.py", line 18858, in <module>
    main()
  File "J:\Projects\mx2\mx.py", line 18839, in main
    retcode = c(command_args)
  File "J:\Projects\mx2\mx_commands.py", line 146, in __call__
    return self.command_function(*args, **kwargs)
  File "J:\Projects\mx2\mx.py", line 16228, in ideinit
    netbeansinit(args.remainder, refreshOnly=refreshOnly, buildProcessorJars=buildProcessorJars, doFsckProjects=False)
  File "J:\Projects\mx2\mx.py", line 14882, in netbeansinit
    _netbeansinit_suite(args, suite, refreshOnly, buildProcessorJars)
  File "J:\Projects\mx2\mx.py", line 15351, in _netbeansinit_suite
    if _check_ide_timestamp(suite, configZip, 'netbeans'):
  File "J:\Projects\mx2\mx.py", line 14090, in _check_ide_timestamp
    if not proj.netbeans_config_up_to_date(configZip):
  File "J:\Projects\mx2\mx.py", line 3062, in netbeans_config_up_to_date
    if configZip.isOlderThan(join(self.dir, 'nbproject/project.xml')):
  File "J:\Projects\mx2\mx.py", line 13406, in isOlderThan
    if getmtime(f) > self.timestamp:
  File "J:\Projects\mx2\mx.py", line 13600, in getmtime
    return os.path.getmtime(name)
  File "J:\Python27\lib\genericpath.py", line 62, in getmtime
    return os.stat(filename).st_mtime
WindowsError: [Error 123] The filename, directory name, or volume label syntax is incorrect: '\\\\?\\J:\\Projects\\mx2\\java\\com.oracle.mxtool.checkcopy\\nbproject/project.xml'
```

This PR switches to relying on `join` to use the right path separator, which fixes the problem.