### PR TITLE
[Python 3] Minor syntax compatibility fixes

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -2473,7 +2473,7 @@ class LayoutDistribution(AbstractDistribution):
                             archiver.add(extracted_file, arcname, provenance)
                             if tarinfo.isdir():
                                 # use a safe mode while extracting, fix later
-                                os.chmod(extracted_file, 0700)
+                                os.chmod(extracted_file, int('0700', 8))
                                 directories.append(tarinfo)
 
                     # Reverse sort directories.
@@ -10993,7 +10993,7 @@ def _waitWithTimeout(process, args, timeout, nonZeroIsFatal=True):
         while True:
             try:
                 return os.waitpid(pid, os.WNOHANG)
-            except OSError, e:
+            except OSError as e:
                 if e.errno == errno.EINTR:
                     continue
                 raise


### PR DESCRIPTION
This PR fixes 2 minor issues with syntax incompatibilities between python 2 and 3.

- Octal literal syntax is not portable, so I'm falling back to parsing a string as base 8.
See: https://portingguide.readthedocs.io/en/latest/numbers.html#octal-literals

- The comma syntax for aliasing exceptions is not portable, but we can use `as` instead.
See: https://portingguide.readthedocs.io/en/latest/exceptions.html#the-new-except-syntax