### PR TITLE
[Python 3] Work around non-portable modules

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -45,7 +45,7 @@ except ImportError:
     from xml.etree.ElementTree import parse as etreeParse
 
 import os, errno, time, subprocess, shlex, types, zipfile, signal, tempfile, platform
-from mx_portable import StringIO, builtins, urllib2, urlparse
+from mx_portable import StringIO, builtins, urllib_request, urllib_error, urllib_parse
 import textwrap
 import socket
 import tarfile, gzip
@@ -4428,7 +4428,7 @@ def _get_path_in_cache(name, sha1, urls, ext=None, sources=False, oldPath=False)
     if ext is None:
         for url in urls:
             # Use extension of first URL whose path component ends with a non-empty extension
-            o = urlparse.urlparse(url)
+            o = urllib_parse.urlparse(url)
             if o.path == "/remotecontent" and o.query.startswith("filepath"):
                 path = o.query
             else:
@@ -4464,8 +4464,8 @@ def _urlopen(*args, **kwargs):
 
     while True:
         try:
-            return urllib2.urlopen(*args, **kwargs)
-        except (urllib2.HTTPError) as e:
+            return urllib_request.urlopen(*args, **kwargs)
+        except (urllib_error.HTTPError) as e:
             if e.code == 500:
                 if error500_attempts < error500_limit:
                     error500_attempts += 1
@@ -4474,12 +4474,12 @@ def _urlopen(*args, **kwargs):
                     time.sleep(0.2)
                     continue
             raise
-        except urllib2.URLError as e:
+        except urllib_error.HTTPError as e:
             if isinstance(e.reason, socket.error):
                 if e.reason.errno == errno.EINTR and 'timeout' in kwargs and is_interactive():
                     warn("urlopen() failed with EINTR. Retrying without timeout.")
                     del kwargs['timeout']
-                    return urllib2.urlopen(*args, **kwargs)
+                    return urllib_request.urlopen(*args, **kwargs)
                 if e.reason.errno == errno.EINPROGRESS:
                     if on_timeout():
                         continue
@@ -6945,10 +6945,10 @@ class BinaryVC(VC):
 
 def _hashFromUrl(url):
     logvv('Retrieving SHA1 from {}'.format(url))
-    hashFile = urllib2.urlopen(url)
+    hashFile = urllib_request.urlopen(url)
     try:
         return hashFile.read()
-    except urllib2.URLError as e:
+    except urllib_error.HTTPError as e:
         _suggest_http_proxy_error(e)
         abort('Error while retrieving sha1 {}: {}'.format(url, str(e)))
     finally:
@@ -7052,7 +7052,7 @@ class MavenRepo:
         logv('Retrieving and parsing {0}'.format(metadataUrl))
         try:
             metadataFile = _urlopen(metadataUrl, timeout=10)
-        except urllib2.HTTPError as e:
+        except urllib_error.HTTPError as e:
             _suggest_http_proxy_error(e)
             abort('Error while retrieving metadata for {}:{}: {}'.format(groupId, artifactId, str(e)))
         try:
@@ -7077,7 +7077,7 @@ class MavenRepo:
                     snapshot_metadataUrl = self.getSnapshotUrl(groupId, artifactId, version_str)
                     try:
                         snapshot_metadataFile = _urlopen(snapshot_metadataUrl, timeout=10)
-                    except urllib2.HTTPError as e:
+                    except urllib_error.HTTPError as e:
                         logv('Version {0} not accessible. Try previous snapshot.'.format(metadataUrl))
                         snapshot_metadataFile = None
 
@@ -7088,7 +7088,7 @@ class MavenRepo:
                         break
 
             return MavenArtifactVersions(latestVersionString, releaseVersionString, versionStrings)
-        except urllib2.URLError as e:
+        except urllib_error.HTTPError as e:
             abort('Error while retrieving versions for {0}:{1}: {2}'.format(groupId, artifactId, str(e)))
         finally:
             if metadataFile:
@@ -7103,8 +7103,8 @@ class MavenRepo:
         logv('Retrieving and parsing {0}'.format(metadataUrl))
         try:
             metadataFile = _urlopen(metadataUrl, timeout=10)
-        except urllib2.URLError as e:
-            if isinstance(e, urllib2.HTTPError) and e.code == 404:
+        except urllib_error.HTTPError as e:
+            if isinstance(e, urllib_error.HTTPError) and e.code == 404:
                 return None
             _suggest_http_proxy_error(e)
             abort('Error while retrieving snapshot for {}:{}:{}: {}'.format(groupId, artifactId, version, str(e)))
@@ -7953,7 +7953,7 @@ class SiblingSuiteModel(SuiteModel):
         for urlinfo in suite_import.urlinfos:
             if urlinfo.abs_kind() == 'source':
                 # 'https://github.com/graalvm/graal.git' -> 'graal'
-                base, _ = os.path.splitext(basename(urlparse.urlparse(urlinfo.url).path))
+                base, _ = os.path.splitext(basename(urllib_parse.urlparse(urlinfo.url).path))
                 if base: break
         if base:
             path = join(SiblingSuiteModel.siblings_dir(importer_dir), base)
@@ -8161,7 +8161,7 @@ class SuiteImport:
 def _validate_abolute_url(urlstr, acceptNone=False):
     if urlstr is None:
         return acceptNone
-    url = urlparse.urlsplit(urlstr)
+    url = urllib_parse.urlsplit(urlstr)
     return url.scheme and (url.netloc or url.path)
 
 class SCMMetadata(object):
@@ -12256,12 +12256,12 @@ def _attempt_download(url, path, jarEntryName=None):
 
             return True
 
-    except (IOError, socket.timeout, urllib2.HTTPError) as e:
+    except (IOError, socket.timeout, urllib_error.HTTPError) as e:
         # In case of an exception the temp file is removed automatically, so no cleanup is necessary
         log_error("Error reading from " + url + ": " + str(e))
         _suggest_http_proxy_error(e)
         _suggest_tlsv1_error(e)
-        if isinstance(e, urllib2.HTTPError) and e.code == 500:
+        if isinstance(e, urllib_error.HTTPError) and e.code == 500:
             return "retry"
     finally:
         if conn:
@@ -18221,7 +18221,7 @@ def _find_suite_import(importing_suite, suite_import, fatalIfMissing=True, load=
             # Try use the URL first so that a big repo is cloned to a local
             # directory whose named is based on the repo instead of a suite
             # nested in the big repo.
-            root, _ = os.path.splitext(basename(urlparse.urlparse(url).path))
+            root, _ = os.path.splitext(basename(urllib_parse.urlparse(url).path))
             if root:
                 import_dir = join(SiblingSuiteModel.siblings_dir(importing_suite.dir), root)
             else:
@@ -18618,8 +18618,8 @@ def _install_socks_proxy_opener(proxytype, proxyaddr, proxyport=None):
     else:
         abort("Unknown Socks Proxy type {0}".format(proxytype))
 
-    opener = urllib2.build_opener(SocksiPyHandler(proxytype, proxyaddr, proxyport))
-    urllib2.install_opener(opener)
+    opener = urllib_request.build_opener(SocksiPyHandler(proxytype, proxyaddr, proxyport))
+    urllib_request.install_opener(opener)
 
 
 def main():

--- a/mx_downstream.py
+++ b/mx_downstream.py
@@ -30,7 +30,7 @@ from __future__ import print_function
 
 from os.path import join, exists, isabs, basename
 from argparse import ArgumentParser
-from urlparse import urlparse
+from mx_portable import urlparse
 import shutil
 import os
 import mx

--- a/mx_downstream.py
+++ b/mx_downstream.py
@@ -30,7 +30,7 @@ from __future__ import print_function
 
 from os.path import join, exists, isabs, basename
 from argparse import ArgumentParser
-from mx_portable import urlparse
+from mx_portable import urllib_parse
 import shutil
 import os
 import mx
@@ -118,7 +118,7 @@ def testdownstream(suite, repoUrls, relTargetSuiteDir, mxCommands, branch=None):
     targetDir = None
     for repoUrl in repoUrls:
         # Deduce a target name from the target URL
-        url = urlparse(repoUrl)
+        url = urllib_parse.urlparse(repoUrl)
         targetName = url.path
         if targetName.rfind('/') != -1:
             targetName = targetName[targetName.rfind('/') + 1:]

--- a/mx_javamodules.py
+++ b/mx_javamodules.py
@@ -30,7 +30,7 @@ import os
 import re
 import zipfile
 import pickle
-import StringIO
+from mx_portable import StringIO
 import shutil
 import itertools
 from os.path import join, exists, dirname, basename
@@ -145,7 +145,7 @@ class JavaModuleDescriptor(object):
         """
         Gets this module descriptor expressed as the contents of a ``module-info.java`` file.
         """
-        out = StringIO.StringIO()
+        out = StringIO()
         print('module ' + self.name + ' {', file=out)
         for dependency, modifiers in sorted(self.requires.iteritems()):
             modifiers_string = (' '.join(sorted(modifiers)) + ' ') if len(modifiers) != 0 else ''

--- a/mx_portable.py
+++ b/mx_portable.py
@@ -1,0 +1,13 @@
+import sys
+
+if sys.version_info[0] < 3:
+    from StringIO import StringIO     #pylint: disable=unused-import
+    import __builtin__ as builtins    #pylint: disable=unused-import
+    from urllib2 import urlopen, build_opener, install_opener, HTTPError, URLError #pylint: disable=unused-import
+    from urlparse import urlparse, urlsplit #pylint: disable=unused-import
+else:
+    from io import StringIO           #pylint: disable=unused-import
+    import builtins                   #pylint: disable=unused-import
+    from urllib.request import urlopen, build_opener, install_opener #pylint: disable=unused-import,E0611
+    from urllib.error import HTTPError, URLError #pylint: disable=unused-import,E0611
+    from urllib.parse import urlparse, urlsplit #pylint: disable=unused-import,E0611

--- a/mx_portable.py
+++ b/mx_portable.py
@@ -1,13 +1,26 @@
 import sys
 
+def _agregate_module(name, *args):
+    """
+    Creates a module with the name 'name' and adds all the symbols from the
+    argument modules to it.
+    """
+    from types import ModuleType
+    result = ModuleType(name)
+    for mod in args:
+        for symbol in mod.__all__:
+            result.__dict__[symbol] = mod.__dict__[symbol]
+    return result
+
 if sys.version_info[0] < 3:
     from StringIO import StringIO     #pylint: disable=unused-import
     import __builtin__ as builtins    #pylint: disable=unused-import
-    from urllib2 import urlopen, build_opener, install_opener, HTTPError, URLError #pylint: disable=unused-import
-    from urlparse import urlparse, urlsplit #pylint: disable=unused-import
+    import urllib2 #pylint: disable=unused-import
+    import urlparse #pylint: disable=unused-import
 else:
     from io import StringIO           #pylint: disable=unused-import
     import builtins                   #pylint: disable=unused-import
-    from urllib.request import urlopen, build_opener, install_opener #pylint: disable=unused-import,E0611
-    from urllib.error import HTTPError, URLError #pylint: disable=unused-import,E0611
-    from urllib.parse import urlparse, urlsplit #pylint: disable=unused-import,E0611
+    import urllib.request             #pylint: disable=unused-import,no-name-in-module
+    import urllib.error               #pylint: disable=unused-import,no-name-in-module
+    urllib2 = _agregate_module('urllib2', urllib.request, urllib.error)
+    import urllib.parse as urlparse #pylint: disable=unused-import,no-name-in-module

--- a/mx_portable.py
+++ b/mx_portable.py
@@ -1,26 +1,16 @@
 import sys
 
-def _agregate_module(name, *args):
-    """
-    Creates a module with the name 'name' and adds all the symbols from the
-    argument modules to it.
-    """
-    from types import ModuleType
-    result = ModuleType(name)
-    for mod in args:
-        for symbol in mod.__all__:
-            result.__dict__[symbol] = mod.__dict__[symbol]
-    return result
-
 if sys.version_info[0] < 3:
-    from StringIO import StringIO     #pylint: disable=unused-import
-    import __builtin__ as builtins    #pylint: disable=unused-import
-    import urllib2 #pylint: disable=unused-import
-    import urlparse #pylint: disable=unused-import
+    from StringIO import StringIO                    #pylint: disable=unused-import
+    import __builtin__ as builtins                   #pylint: disable=unused-import
+    import urllib2                                   #pylint: disable=unused-import
+    urllib_request = urllib2
+    urllib_error = urllib2
+    del urllib2
+    import urlparse as urllib_parse                  #pylint: disable=unused-import
 else:
-    from io import StringIO           #pylint: disable=unused-import
-    import builtins                   #pylint: disable=unused-import
-    import urllib.request             #pylint: disable=unused-import,no-name-in-module
-    import urllib.error               #pylint: disable=unused-import,no-name-in-module
-    urllib2 = _agregate_module('urllib2', urllib.request, urllib.error)
-    import urllib.parse as urlparse #pylint: disable=unused-import,no-name-in-module
+    from io import StringIO                          #pylint: disable=unused-import
+    import builtins                                  #pylint: disable=unused-import
+    import urllib.request as urllib_request          #pylint: disable=unused-import,no-name-in-module
+    import urllib.error as urllib_error              #pylint: disable=unused-import,no-name-in-module
+    import urllib.parse as urllib_parse              #pylint: disable=unused-import,no-name-in-module

--- a/select_jdk.py
+++ b/select_jdk.py
@@ -29,7 +29,7 @@ from __future__ import print_function
 import os, tempfile
 from argparse import ArgumentParser, REMAINDER
 from os.path import exists, expanduser, join, isdir, isfile, realpath, dirname, abspath
-import StringIO
+from mx_portable import StringIO
 
 def is_valid_jdk(jdk):
     """
@@ -87,7 +87,7 @@ def get_PATH_sep(shell):
 
 def get_shell_commands(args, jdk, extra_jdks):
     setvar_format = get_setvar_format(args.shell)
-    shell_commands = StringIO.StringIO()
+    shell_commands = StringIO()
     print(setvar_format % ('JAVA_HOME', jdk), file=shell_commands)
     if extra_jdks:
         print(setvar_format % ('EXTRA_JAVA_HOMES', os.pathsep.join(extra_jdks)), file=shell_commands)


### PR DESCRIPTION
Some of the modules used by `mx` are not available under Python 3, this PR adds an import indirection to another module called `mx_portable` which imports the right things based on the detected version of python and exposes them under a common name.

These names are:

`__builtin__` -> `buitlins`
`urlparse` -> `urllib_parse` (after the python 3 `urllib.parse`)
`urllib2` -> `urllib_request` (after the python 3 `urllib.request`)
`urllib2` -> `urllib_error` (urllib2 was split into 2 modules in P3)

The class StringIO comes from a different module in Python 3,  so I've removed the module prefix from the code everywhere and am just accessing the class name directly.