### PR TITLE
[WIP] [Python 3] Remove use of types module and basestring

### DIFF
--- a/mx_compat.py
+++ b/mx_compat.py
@@ -26,7 +26,7 @@
 
 from __future__ import print_function
 
-import sys, inspect, re, types, bisect
+import sys, inspect, re, bisect
 from collections import OrderedDict
 from os.path import join
 import mx
@@ -389,12 +389,12 @@ def _ensureCompatLoaded():
 
         def flattenClassTree(tree):
             root = tree[0][0]
-            assert isinstance(root, types.TypeType), root
+            assert isinstance(root, type), root
             yield root
             if len(tree) > 1:
                 assert len(tree) == 2
                 rest = tree[1]
-                assert isinstance(rest, types.ListType), rest
+                assert isinstance(rest, list), rest
                 for c in flattenClassTree(rest):
                     yield c
 


### PR DESCRIPTION
Python 3.1 removes the builtin types from the `types.` module, so it's use in that regard is non-portable. This PR changes the use of `types` with builtin type names where appropriate.

Additionally, since `basestring` is no longer in Python 3, it's usage is exchanged for `str`. The difference is that `basestring` is a common super type for `unicode` and `str`, so this is technically more restrictive, but also portable. I don't think using `str` instead of `basestring` will matter in practice, since it's only being used in type checks with `isinstance` to check if something is a string, and almost all the code uses the `str` type, since it's the default for strings.