### PR TITLE
[Python 3] Work around odict_keys not indexable

### DIFF
--- a/mx_compat.py
+++ b/mx_compat.py
@@ -373,13 +373,13 @@ class MxCompatibility5194(MxCompatibility5181):  # pylint: disable=too-many-ance
 
 def minVersion():
     _ensureCompatLoaded()
-    return _versionsMap.keys()[0]
+    return next(iter(_versionsMap.keys()))
 
 def getMxCompatibility(version):
     """:rtype: MxCompatibility500"""
     if version < minVersion():  # ensures compat loaded
         return None
-    keys = _versionsMap.keys()
+    keys = list(_versionsMap.keys())
     return _versionsMap[keys[bisect.bisect_right(keys, version)-1]]
 
 _versionsMap = OrderedDict()


### PR DESCRIPTION
The Python 3 type returned by `OrderedDict.keys()` is not indexable, but it is iterable. This PR finds an alternative to the indexing operator currently used.

In one case where the first element is needed, we just create an iterator and retrieve the first element.

In an other, where indexing behavior is needed, we convert the key view to a list first.