### PR TITLE
Convert path separators in _safe_path

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -13593,6 +13593,7 @@ def _safe_path(path):
     https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#maxpath
     """
     if get_os() == 'windows':
+        path = path.replace("/", "\\")
         if isabs(path):
             if path.startswith('\\\\'):
                 if path[2:].startswith('?\\'):


### PR DESCRIPTION
Fixes: #166

Some paths in suite config files can contain `/` as a path separator, which can not be used on windows.

Luckily the `_safe_path` function is used in a lot of places to work around the max path length on Windows. This PR adds an additional step to this function which also converts unix path separators to Windows ones when Windows is the detected OS.