### PR TITLE
Correct error log message post compiler daemon crash

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -4282,7 +4282,7 @@ class CompilerDaemon(Daemon):
         if retcode:
             if _opts.verbose:
                 if _opts.very_verbose:
-                    raise subprocess.CalledProcessError(retcode, self.jdk.java + ' '.join(compilerArgs))
+                    raise subprocess.CalledProcessError(retcode, self.jdk.javac + ' ' + ' '.join(compilerArgs))
                 else:
                     log('[exit code: ' + str(retcode) + ']')
             abort(retcode)

--- a/mx.py
+++ b/mx.py
@@ -4282,7 +4282,7 @@ class CompilerDaemon(Daemon):
         if retcode:
             if _opts.verbose:
                 if _opts.very_verbose:
-                    raise subprocess.CalledProcessError(retcode, self.jdk.javac + ' ' + ' '.join(compilerArgs))
+                    retcode = str(subprocess.CalledProcessError(retcode, self.jdk.javac + ' ' + ' '.join(compilerArgs)))
                 else:
                     log('[exit code: ' + str(retcode) + ']')
             abort(retcode)


### PR DESCRIPTION
Correcting the error message printed when the request sent to the compiler daemon fails: compiler daemon is called javac and not java. Also adding a space to separate the command from the arguments.

On the back of [the discussions](https://github.com/oracle/graal/issues/1243#issuecomment-500603776) on the reported issue https://github.com/oracle/graal/issues/1243

See output at https://circleci.com/gh/neomatrix369/awesome-graal/423 (search for `CalledProcessError`, we now see the correct message:

```
CalledProcessError: Command '/root/project/graal-jvmci-8/openjdk1.8.0-internal/linux-amd64/product/bin/javac -g -d /root/project/graal/compiler/mxbuild/src/org.graalvm.compiler.replacements.test/bin
[snipped]
```