### PR TITLE
Upgrade to checkstyle 8.26

### DIFF
--- a/java/com.oracle.mxtool.junit/.checkstyle_checks.xml
+++ b/java/com.oracle.mxtool.junit/.checkstyle_checks.xml
@@ -28,9 +28,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -141,6 +138,9 @@
       <property name="onCommentFormat" value="@formatter:on"/>
       <property name="checkFormat" value=".*"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) (20[0-9][0-9], )?20[0-9][0-9], Oracle and/or its affiliates. All rights reserved.\n \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.\n \*\n \* This code is free software; you can redistribute it and/or modify it\n \* under the terms of the GNU General Public License version 2 only, as\n \* published by the Free Software Foundation.  Oracle designates this\n \* particular file as subject to the &quot;Classpath&quot; exception as provided\n \* by Oracle in the LICENSE file that accompanied this code.\n \*\n \* This code is distributed in the hope that it will be useful, but WITHOUT\n \* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or\n \* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License\n \* version 2 for more details \(a copy is included in the LICENSE file that\n \* accompanied this code\).\n \*\n \* You should have received a copy of the GNU General Public License version\n \* 2 along with this work; if not, write to the Free Software Foundation,\n \* Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.\n \*\n \* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA\n \* or visit www.oracle.com if you need additional information or have any\n \* questions.\n \*/\n"/>

--- a/mx.mx/suite.py
+++ b/mx.mx/suite.py
@@ -222,6 +222,20 @@ suite = {
       }
     },
 
+    "CHECKSTYLE_8.26" : {
+      "urls" : [
+        "https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/checkstyle-8.26-all.jar",
+        "https://github.com/checkstyle/checkstyle/releases/download/checkstyle-8.26/checkstyle-8.26-all.jar",
+      ],
+      "sha1" : "9349178590f0820476f63074bb204aefb8c61212",
+      "licence" : "LGPLv21",
+      "maven" : {
+        "groupId" : "com.puppycrawl.tools",
+        "artifactId" : "checkstyle",
+        "version" : "8.26",
+      }
+    },
+
     "HAMCREST" : {
       "sha1" : "42a25dc3219429f0e5d060061f71acb49bf010a0",
       "sourceSha1" : "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b",
@@ -478,7 +492,7 @@ suite = {
         "JUNIT",
       ],
       "javaCompliance" : "1.8+",
-      "checkstyleVersion" : "8.8",
+      "checkstyleVersion" : "8.26",
     },
 
     "com.oracle.mxtool.junit.jdk9" : {


### PR DESCRIPTION
and move LineLengthCheck outside of TreeWalker.

This is required to make all .checkstyle_checks.xml files compatible with checkstyle 8.24 and later.

See https://checkstyle.sourceforge.io/releasenotes.html#Release_8.24 and checkstyle/checkstyle#2116