### PR TITLE
Add --jmods-dir

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -526,6 +526,7 @@ environment variables:
         self.add_argument('--version', action='store_true', help='print version and exit')
         self.add_argument('--mx-tests', action='store_true', help='load mxtests suite (mx debugging)')
         self.add_argument('--jdk', action='store', help='JDK to use for the "java" command', metavar='<tag:compliance>')
+        self.add_argument('--jmods-dir', action='store', help='path to built jmods (default JAVA_HOME/jmods)', metavar='<path>')
         self.add_argument('--version-conflict-resolution', dest='version_conflict_resolution', action='store', help='resolution mechanism used when a suite is imported with different versions', default='suite', choices=['suite', 'none', 'latest', 'latest_all', 'ignore'])
         self.add_argument('-c', '--max-cpus', action='store', type=int, dest='cpu_count', help='the maximum number of cpus to use during build', metavar='<cpus>', default=None)
         self.add_argument('--strip-jars', action='store_true', help='produce and use stripped jars in all mx commands.')

--- a/mx_javamodules.py
+++ b/mx_javamodules.py
@@ -815,7 +815,7 @@ def make_java_module(dist, jdk, javac_daemon=None, alt_module_info_name=None):
                     javac_args.append('--system=none')
                     if requires:
                         javac_args.append('--limit-modules=' + ','.join(requires.keys()))
-                    jdk_jmods = join(jdk.home, 'jmods')
+                    jdk_jmods = (mx.get_opts().jmods_dir or join(jdk.home, 'jmods'))
                     if not exists(jdk_jmods):
                         mx.abort('Missing directory containing JMOD files: ' + jdk_jmods)
                     modulepath_jars.extend((join(jdk_jmods, m) for m in os.listdir(jdk_jmods) if m.endswith('.jmod')))


### PR DESCRIPTION
This option allows us to build Graal with an exploded JDK like this:

```
mx --java-home=$(JDK_OUTPUTDIR) --jmods-dir=$(IMAGES_OUTPUTDIR)/jmods
```

This is necessary if someone wants to build a JDK image with an upstream Graal module.