### PR TITLE
Add --target-platform to jmod invocation

### DIFF
--- a/mx_javamodules.py
+++ b/mx_javamodules.py
@@ -869,7 +869,10 @@ def make_java_module(dist, jdk, javac_daemon=None, alt_module_info_name=None):
                         os.remove(jmod_path)
 
                     jdk_jmod = join(jdk_jmods, basename(jmod_path))
-                    jmod_args = ['create', '--class-path=' + dest_dir]
+                    target_os = mx.get_os()
+                    target_os = 'macos' if target_os == 'darwin' else target_os
+                    target_arch = mx.get_arch()
+                    jmod_args = ['create', '--target-platform={}-{}'.format(target_os, target_arch), '--class-path=' + dest_dir]
                     if exists(jdk_jmod):
                         with ZipFile(jdk_jmod, 'r') as zf:
                             # Copy commands and legal notices (if any) from JDK version of the module


### PR DESCRIPTION
The JDK regression test `tools/jlink/plugins/SystemModuleDescriptors/SystemModulesTest.java` fails with:

```
java.lang.NullPointerException
	at SystemModulesTest.checkAttributes(SystemModulesTest.java:115)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:658)
	at SystemModulesTest.testSystemModules(SystemModulesTest.java:71)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:85)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:639)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:821)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1131)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:108)
	at org.testng.TestRunner.privateRun(TestRunner.java:773)
	at org.testng.TestRunner.run(TestRunner.java:623)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:357)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:352)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:310)
	at org.testng.SuiteRunner.run(SuiteRunner.java:259)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1185)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1110)
	at org.testng.TestNG.run(TestNG.java:1018)
	at com.sun.javatest.regtest.agent.TestNGRunner.main(TestNGRunner.java:94)
	at jdk.internal.reflect.GeneratedMethodAccessor11.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:298)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

because the code checks for a `target_platform` class file attribute.  The JDK build system uses the `jmod` option:

```
  --target-platform <String: target-  Target platform                       
    platform>                                                               
```

to add this information.