### PR TITLE
Add `fetch-jdk` command

### DIFF
--- a/jdk_distribution_parser.py
+++ b/jdk_distribution_parser.py
@@ -1,7 +1,7 @@
 #
 # ----------------------------------------------------------------------------------------------------
 #
-# Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -115,22 +115,6 @@ class OpenJDK8(JdkDistribution):
                     "{GITHUB_RELEASES}/{short_version}/{archive}"
                     ).format(GITHUB_URL=GITHUB_URL, GITHUB_RELEASES=GITHUB_RELEASES,
                     short_version=self._short_version, archive=self._archive)
-
-class OpenJDK11(JdkDistribution):
-    _name = "openjdk11"
-    def __init__(self, version):
-        JdkDistribution.__init__(self, version)
-        machine = self.get_machine()
-        self._short_version = version.replace("+", "_")
-        self._filename = "OpenJDK11U-jdk_{machine}_hotspot_{short_version}".format(short_version=self._short_version, machine=machine)
-        self._archive = "{}.tar.gz".format(self._filename)
-        self._url = ("{GITHUB_URL}/AdoptOpenJDK/openjdk11-binaries/"
-                    "{GITHUB_RELEASES}/jdk-{version}/{archive}"
-                    ).format(GITHUB_URL=GITHUB_URL, GITHUB_RELEASES=GITHUB_RELEASES,
-                    version=version, archive=self._archive)
-
-    def get_machine(self):
-        return mx.get_arch().replace("amd", "x") + "_" + mx.get_os().replace("darwin", "mac")
 
 class LabsJDK11CE(JdkDistribution):
     _name = "labsjdk-ce-11"

--- a/jdk_distribution_parser.py
+++ b/jdk_distribution_parser.py
@@ -24,7 +24,7 @@
 #
 # ----------------------------------------------------------------------------------------------------
 #
-import re, json
+import re
 import mx
 from os.path import join
 
@@ -41,13 +41,6 @@ class JdkDistribution(object):
             if dist._name == name:
                 dist(version)
                 return
-    @staticmethod
-    def parse_common_json(common_path):
-        with open(common_path) as common_file:
-            common_cfg = json.load(common_file)
-
-        for distribution in common_cfg["jdks"]:
-            JdkDistribution.parse(distribution, common_cfg["jdks"][distribution]["version"])
 
     @staticmethod
     def choose_dist(quiet=False):

--- a/jdk_distribution_parser.py
+++ b/jdk_distribution_parser.py
@@ -58,10 +58,9 @@ class JdkDistribution(object):
             name=dist.get_name().ljust(25), version=dist.get_version(), default=default))
             index += 1
         while True:
-            print("Select JDK>"), # pylint: disable=expression-not-assigned
             try:
                 try:
-                    choice = input()
+                    choice = input("Select JDK>")
                 except SyntaxError: # Empty line
                     choice = ""
 
@@ -91,7 +90,7 @@ class JdkDistribution(object):
     def get_filename(self):
         return self._filename
 
-    def get_archive(self):
+    def get_archive_name(self):
         return self._archive
 
     def get_url(self):
@@ -106,11 +105,11 @@ class JdkDistribution(object):
     def get_short_version(self):
         return self._short_version
 
-    def get_jdk_folder(self):
+    def get_folder_name(self):
         return "{}-{}".format(self.get_name(), self.get_short_version())
 
-    def get_full_jdk_path(self, jdk_path):
-        return join(jdk_path, self.get_jdk_folder())
+    def get_final_path(self, jdk_path):
+        return join(jdk_path, self.get_folder_name())
 
 class OpenJDK8(JdkDistribution):
     _name = "openjdk8"

--- a/jdk_distribution_parser.py
+++ b/jdk_distribution_parser.py
@@ -132,7 +132,7 @@ class OpenJDK11(JdkDistribution):
     def get_machine(self):
         return mx.get_arch().replace("amd", "x") + "_" + mx.get_os().replace("darwin", "mac")
 
-class LabsJDKCE(JdkDistribution):
+class LabsJDK11CE(JdkDistribution):
     _name = "labsjdk-ce-11"
     def __init__(self, version):
         JdkDistribution.__init__(self, version)

--- a/jdk_distribution_parser.py
+++ b/jdk_distribution_parser.py
@@ -40,7 +40,6 @@ class JdkDistribution(object):
         for dist in JdkDistribution.__subclasses__():
             if dist._name == name:
                 dist(version)
-                return
 
     @staticmethod
     def choose_dist(quiet=False):
@@ -51,7 +50,7 @@ class JdkDistribution(object):
         for dist in JdkDistribution._jdk_distributions:
             default = " " if dist.get_name() != JdkDistribution._DEFAULT_JDK else "*"
             print("[{index}]{default} {name} | {version}".format(index=index,
-            name=dist.get_name().ljust(15), version=dist.get_version(), default=default))
+            name=dist.get_name().ljust(25), version=dist.get_version(), default=default))
             index += 1
         while True:
             print("Select JDK>"), # pylint: disable=expression-not-assigned
@@ -104,10 +103,26 @@ class OpenJDK8(JdkDistribution):
         self._filename = "openjdk-{}-{}".format(version, machine)
         self._short_version = re.sub(r".*(jvmci.*)", "\\1", version)
         self._archive = "{}.tar.gz".format(self._filename)
-        self._url = ("{GITHUB_URL}/graalvm/openjdk8-jvmci-builder/"
+        self._url = ("{GITHUB_URL}/graalvm/graal-jvmci-8/"
                     "{GITHUB_RELEASES}/{short_version}/{archive}"
                     ).format(GITHUB_URL=GITHUB_URL, GITHUB_RELEASES=GITHUB_RELEASES,
                     short_version=self._short_version, archive=self._archive)
+
+class OpenJDK8Debug(JdkDistribution):
+    _name = "openjdk8"
+    def __init__(self, version):
+        JdkDistribution.__init__(self, version)
+        machine = mx.get_os() + '-' + mx.get_arch()
+        self._filename = "openjdk-{}-fastdebug-{}".format(version, machine)
+        self._short_version = re.sub(r".*(jvmci.*)", "\\1", version)
+        self._archive = "{}.tar.gz".format(self._filename)
+        self._url = ("{GITHUB_URL}/graalvm/graal-jvmci-8/"
+                    "{GITHUB_RELEASES}/{short_version}/{archive}"
+                    ).format(GITHUB_URL=GITHUB_URL, GITHUB_RELEASES=GITHUB_RELEASES,
+                    short_version=self._short_version, archive=self._archive)
+
+    def get_name(self):
+        return self._name + "-fastdebug"
 
 class LabsJDK11CE(JdkDistribution):
     _name = "labsjdk-ce-11"
@@ -121,3 +136,19 @@ class LabsJDK11CE(JdkDistribution):
                     "{GITHUB_RELEASES}/{short_version}/{archive}"
                     ).format(GITHUB_URL=GITHUB_URL, GITHUB_RELEASES=GITHUB_RELEASES,
                     short_version=self._short_version, archive=self._archive)
+
+class LabsJDK11CEDebug(JdkDistribution):
+    _name = "labsjdk-ce-11"
+    def __init__(self, version):
+        JdkDistribution.__init__(self, version)
+        machine = mx.get_os() + '-' + mx.get_arch()
+        self._filename = "labsjdk-{}-debug-{}".format(version, machine)
+        self._short_version = re.sub(r".*(jvmci.*)", "\\1", version)
+        self._archive = "{}.tar.gz".format(self._filename)
+        self._url = ("{GITHUB_URL}/graalvm/labs-openjdk-11/"
+                    "{GITHUB_RELEASES}/{short_version}/{archive}"
+                    ).format(GITHUB_URL=GITHUB_URL, GITHUB_RELEASES=GITHUB_RELEASES,
+                    short_version=self._short_version, archive=self._archive)
+
+    def get_name(self):
+        return self._name + "-debug"

--- a/jdk_distribution_parser.py
+++ b/jdk_distribution_parser.py
@@ -47,18 +47,35 @@ class JdkDistribution(object):
             return JdkDistribution.by_name(JdkDistribution._DEFAULT_JDK)
 
         index = 1
+        default_choice = 1
         for dist in JdkDistribution._jdk_distributions:
-            default = " " if dist.get_name() != JdkDistribution._DEFAULT_JDK else "*"
+            if dist.get_name() == JdkDistribution._DEFAULT_JDK:
+                default_choice = index
+                default = "*"
+            else:
+                default = " "
             print("[{index}]{default} {name} | {version}".format(index=index,
             name=dist.get_name().ljust(25), version=dist.get_version(), default=default))
             index += 1
         while True:
             print("Select JDK>"), # pylint: disable=expression-not-assigned
             try:
-                index = int(input()) - 1
+                try:
+                    choice = input()
+                except SyntaxError: # Empty line
+                    choice = ""
+
+                if choice == "":
+                    index = default_choice - 1
+                else:
+                    index = int(choice) - 1
+
+                if index < 0:
+                    raise IndexError
+
                 return JdkDistribution._jdk_distributions[index]
             except (SyntaxError, NameError, IndexError):
-                pass
+                mx.warn("Invalid selection!")
 
     @staticmethod
     def by_name(name):

--- a/jdk_distribution_parser.py
+++ b/jdk_distribution_parser.py
@@ -44,7 +44,7 @@ class JdkDistribution(object):
     @staticmethod
     def parse_common_json(common_path):
         with open(common_path) as common_file:
-                common_cfg = json.load(common_file)
+            common_cfg = json.load(common_file)
 
         for distribution in common_cfg["jdks"]:
             JdkDistribution.parse(distribution, common_cfg["jdks"][distribution]["version"])
@@ -52,16 +52,16 @@ class JdkDistribution(object):
     @staticmethod
     def choose_dist(quiet=False):
         if quiet:
-           return JdkDistribution.by_name(JdkDistribution._DEFAULT_JDK)
- 
+            return JdkDistribution.by_name(JdkDistribution._DEFAULT_JDK)
+
         index = 1
         for dist in JdkDistribution._jdk_distributions:
             default = " " if dist.get_name() != JdkDistribution._DEFAULT_JDK else "*"
-            print("[{index}]{default} {name} | {version}".format(index=index, 
+            print("[{index}]{default} {name} | {version}".format(index=index,
             name=dist.get_name().ljust(15), version=dist.get_version(), default=default))
             index += 1
         while True:
-            print("Select JDK>"),
+            print("Select JDK>"), # pylint: disable=expression-not-assigned
             try:
                 index = int(input()) - 1
                 return JdkDistribution._jdk_distributions[index]
@@ -91,9 +91,6 @@ class JdkDistribution(object):
     def get_name(self):
         return self._name
 
-    def get_filename(self):
-        return self._filename
-    
     def get_version(self):
         return self._version
 
@@ -116,9 +113,8 @@ class OpenJDK8(JdkDistribution):
         self._archive = "{}.tar.gz".format(self._filename)
         self._url = ("{GITHUB_URL}/graalvm/openjdk8-jvmci-builder/"
                     "{GITHUB_RELEASES}/{short_version}/{archive}"
-                    ).format(GITHUB_URL=GITHUB_URL, GITHUB_RELEASES=GITHUB_RELEASES, 
-                    version=version, short_version=self._short_version, archive=self._archive, 
-                    machine=machine)
+                    ).format(GITHUB_URL=GITHUB_URL, GITHUB_RELEASES=GITHUB_RELEASES,
+                    short_version=self._short_version, archive=self._archive)
 
 class OpenJDK11(JdkDistribution):
     _name = "openjdk11"
@@ -130,9 +126,8 @@ class OpenJDK11(JdkDistribution):
         self._archive = "{}.tar.gz".format(self._filename)
         self._url = ("{GITHUB_URL}/AdoptOpenJDK/openjdk11-binaries/"
                     "{GITHUB_RELEASES}/jdk-{version}/{archive}"
-                    ).format(GITHUB_URL=GITHUB_URL, GITHUB_RELEASES=GITHUB_RELEASES, 
-                    version=version, short_version=self._short_version, archive=self._archive, 
-                    machine=machine)
+                    ).format(GITHUB_URL=GITHUB_URL, GITHUB_RELEASES=GITHUB_RELEASES,
+                    version=version, archive=self._archive)
 
     def get_machine(self):
         return mx.get_arch().replace("amd", "x") + "_" + mx.get_os().replace("darwin", "mac")
@@ -147,6 +142,5 @@ class LabsJDKCE(JdkDistribution):
         self._archive = "{}.tar.gz".format(self._filename)
         self._url = ("{GITHUB_URL}/graalvm/labs-openjdk-11/"
                     "{GITHUB_RELEASES}/{short_version}/{archive}"
-                    ).format(GITHUB_URL=GITHUB_URL, GITHUB_RELEASES=GITHUB_RELEASES, 
-                    version=version, short_version=self._short_version, archive=self._archive, 
-                    machine=machine)
+                    ).format(GITHUB_URL=GITHUB_URL, GITHUB_RELEASES=GITHUB_RELEASES,
+                    short_version=self._short_version, archive=self._archive)

--- a/jdk_distribution_parser.py
+++ b/jdk_distribution_parser.py
@@ -1,0 +1,152 @@
+#
+# ----------------------------------------------------------------------------------------------------
+#
+# Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+# ----------------------------------------------------------------------------------------------------
+#
+import re, json
+import mx
+from os.path import join
+
+GITHUB_URL = "https://github.com"
+GITHUB_RELEASES = "releases/download"
+
+class JdkDistribution(object):
+    _jdk_distributions = []
+    _DEFAULT_JDK = "labsjdk-ce-11"
+
+    @staticmethod
+    def parse(name, version):
+        for dist in JdkDistribution.__subclasses__():
+            if dist._name == name:
+                dist(version)
+                return
+    @staticmethod
+    def parse_common_json(common_path):
+        with open(common_path) as common_file:
+                common_cfg = json.load(common_file)
+
+        for distribution in common_cfg["jdks"]:
+            JdkDistribution.parse(distribution, common_cfg["jdks"][distribution]["version"])
+
+    @staticmethod
+    def choose_dist(quiet=False):
+        if quiet:
+           return JdkDistribution.by_name(JdkDistribution._DEFAULT_JDK)
+ 
+        index = 1
+        for dist in JdkDistribution._jdk_distributions:
+            default = " " if dist.get_name() != JdkDistribution._DEFAULT_JDK else "*"
+            print("[{index}]{default} {name} | {version}".format(index=index, 
+            name=dist.get_name().ljust(15), version=dist.get_version(), default=default))
+            index += 1
+        while True:
+            print("Select JDK>"),
+            try:
+                index = int(input()) - 1
+                return JdkDistribution._jdk_distributions[index]
+            except (SyntaxError, NameError, IndexError):
+                pass
+
+    @staticmethod
+    def by_name(name):
+        for dist in JdkDistribution._jdk_distributions:
+            if dist.get_name() == name:
+                return dist
+        mx.abort("Unknown JDK distribution")
+
+    def __init__(self, version):
+        self._version = version
+        self._jdk_distributions.append(self)
+
+    def get_filename(self):
+        return self._filename
+
+    def get_archive(self):
+        return self._archive
+
+    def get_url(self):
+        return self._url
+
+    def get_name(self):
+        return self._name
+
+    def get_filename(self):
+        return self._filename
+    
+    def get_version(self):
+        return self._version
+
+    def get_short_version(self):
+        return self._short_version
+
+    def get_jdk_folder(self):
+        return "{}-{}".format(self.get_name(), self.get_short_version())
+
+    def get_full_jdk_path(self, jdk_path):
+        return join(jdk_path, self.get_jdk_folder())
+
+class OpenJDK8(JdkDistribution):
+    _name = "openjdk8"
+    def __init__(self, version):
+        JdkDistribution.__init__(self, version)
+        machine = mx.get_os() + '-' + mx.get_arch()
+        self._filename = "openjdk-{}-{}".format(version, machine)
+        self._short_version = re.sub(r".*(jvmci.*)", "\\1", version)
+        self._archive = "{}.tar.gz".format(self._filename)
+        self._url = ("{GITHUB_URL}/graalvm/openjdk8-jvmci-builder/"
+                    "{GITHUB_RELEASES}/{short_version}/{archive}"
+                    ).format(GITHUB_URL=GITHUB_URL, GITHUB_RELEASES=GITHUB_RELEASES, 
+                    version=version, short_version=self._short_version, archive=self._archive, 
+                    machine=machine)
+
+class OpenJDK11(JdkDistribution):
+    _name = "openjdk11"
+    def __init__(self, version):
+        JdkDistribution.__init__(self, version)
+        machine = self.get_machine()
+        self._short_version = version.replace("+", "_")
+        self._filename = "OpenJDK11U-jdk_{machine}_hotspot_{short_version}".format(short_version=self._short_version, machine=machine)
+        self._archive = "{}.tar.gz".format(self._filename)
+        self._url = ("{GITHUB_URL}/AdoptOpenJDK/openjdk11-binaries/"
+                    "{GITHUB_RELEASES}/jdk-{version}/{archive}"
+                    ).format(GITHUB_URL=GITHUB_URL, GITHUB_RELEASES=GITHUB_RELEASES, 
+                    version=version, short_version=self._short_version, archive=self._archive, 
+                    machine=machine)
+
+    def get_machine(self):
+        return mx.get_arch().replace("amd", "x") + "_" + mx.get_os().replace("darwin", "mac")
+
+class LabsJDKCE(JdkDistribution):
+    _name = "labsjdk-ce-11"
+    def __init__(self, version):
+        JdkDistribution.__init__(self, version)
+        machine = mx.get_os() + '-' + mx.get_arch()
+        self._filename = "labsjdk-{}-{}".format(version, machine)
+        self._short_version = re.sub(r".*(jvmci.*)", "\\1", version)
+        self._archive = "{}.tar.gz".format(self._filename)
+        self._url = ("{GITHUB_URL}/graalvm/labs-openjdk-11/"
+                    "{GITHUB_RELEASES}/{short_version}/{archive}"
+                    ).format(GITHUB_URL=GITHUB_URL, GITHUB_RELEASES=GITHUB_RELEASES, 
+                    version=version, short_version=self._short_version, archive=self._archive, 
+                    machine=machine)

--- a/mx.py
+++ b/mx.py
@@ -773,7 +773,7 @@ def no_suite_loading(func):
     """
     Decorator for commands that need a primary suite but don't need suites to be loaded.
     """
-    _no_suite_loading.append(func.__name__)
+    _no_suite_loading.append(func.__name__.replace("_", "-"))
     return func
 
 # Names of commands that need a primary suite but don't need suites to be discovered.
@@ -785,7 +785,7 @@ def no_suite_discovery(func):
     """
     Decorator for commands that need a primary suite but don't need suites to be discovered.
     """
-    _no_suite_discovery.append(func.__name__)
+    _no_suite_discovery.append(func.__name__.replace("_", "-"))
     return func
 
 

--- a/mx.py
+++ b/mx.py
@@ -744,14 +744,20 @@ currently_loading_suite = DynamicVar(None)
 
 _suite_context_free = ['init', 'version', 'urlrewrite']
 
+def _command_function_names(func):
+    """
+    Generates list of guesses for command name based on its function name
+    """
+    command_names = [func.__name__]
+    if '_' in func.__name__:
+        command_names.append(func.__name__.replace("_", "-"))
+    return command_names
 
 def suite_context_free(func):
     """
     Decorator for commands that don't need a primary suite.
     """
-    _suite_context_free.append(func.__name__)
-    if '_' in func.__name__:
-        _suite_context_free.append(func.__name__.replace("_", "-"))
+    _suite_context_free.extend(_command_function_names(func))
     return func
 
 # Names of commands that don't need a primary suite but will use one if it can be found.
@@ -763,9 +769,7 @@ def optional_suite_context(func):
     """
     Decorator for commands that don't need a primary suite but will use one if it can be found.
     """
-    _optional_suite_context.append(func.__name__)
-    if '_' in func.__name__:
-        _optional_suite_context.append(func.__name__.replace("_", "-"))
+    _optional_suite_context.extend(_command_function_names(func))
     return func
 
 # Names of commands that need a primary suite but don't need suites to be loaded.
@@ -777,9 +781,7 @@ def no_suite_loading(func):
     """
     Decorator for commands that need a primary suite but don't need suites to be loaded.
     """
-    _no_suite_loading.append(func.__name__)
-    if '_' in func.__name__:
-        _no_suite_loading.append(func.__name__.replace("_", "-"))
+    _no_suite_loading.extend(_command_function_names(func))
     return func
 
 # Names of commands that need a primary suite but don't need suites to be discovered.
@@ -791,9 +793,7 @@ def no_suite_discovery(func):
     """
     Decorator for commands that need a primary suite but don't need suites to be discovered.
     """
-    _no_suite_discovery.append(func.__name__)
-    if '_' in func.__name__:
-        _no_suite_discovery.append(func.__name__.replace("_", "-"))
+    _no_suite_discovery.extend(_command_function_names(func))
     return func
 
 

--- a/mx.py
+++ b/mx.py
@@ -19246,7 +19246,7 @@ update_commands("mx", {
     'version': [show_version, ''],
 })
 
-from mx_fetchjdk import fetch_jdk
+import mx_fetchjdk # pylint: disable=unused-import
 
 from mx_unittest import unittest
 from mx_jackpot import jackpot

--- a/mx.py
+++ b/mx.py
@@ -6595,7 +6595,7 @@ class JavaProject(Project, ClasspathDependency):
                             if self.is_test_project() and java_package is None and path_package == '':
                                 # Test projects are allowed to include classes without a package
                                 continue
-                            elif java_package != path_package:
+                            if java_package != path_package:
                                 mismatched_imports[java_source] = java_package
 
             importedPackagesFromProjects = set()

--- a/mx.py
+++ b/mx.py
@@ -749,7 +749,9 @@ def suite_context_free(func):
     """
     Decorator for commands that don't need a primary suite.
     """
-    _suite_context_free.append(func.__name__.replace("_", "-"))
+    _suite_context_free.append(func.__name__)
+    if '_' in func.__name__:
+        _suite_context_free.append(func.__name__.replace("_", "-"))
     return func
 
 # Names of commands that don't need a primary suite but will use one if it can be found.
@@ -761,7 +763,9 @@ def optional_suite_context(func):
     """
     Decorator for commands that don't need a primary suite but will use one if it can be found.
     """
-    _optional_suite_context.append(func.__name__.replace("_", "-"))
+    _optional_suite_context.append(func.__name__)
+    if '_' in func.__name__:
+        _optional_suite_context.append(func.__name__.replace("_", "-"))
     return func
 
 # Names of commands that need a primary suite but don't need suites to be loaded.
@@ -773,7 +777,9 @@ def no_suite_loading(func):
     """
     Decorator for commands that need a primary suite but don't need suites to be loaded.
     """
-    _no_suite_loading.append(func.__name__.replace("_", "-"))
+    _no_suite_loading.append(func.__name__)
+    if '_' in func.__name__:
+        _no_suite_loading.append(func.__name__.replace("_", "-"))
     return func
 
 # Names of commands that need a primary suite but don't need suites to be discovered.
@@ -785,7 +791,9 @@ def no_suite_discovery(func):
     """
     Decorator for commands that need a primary suite but don't need suites to be discovered.
     """
-    _no_suite_discovery.append(func.__name__.replace("_", "-"))
+    _no_suite_discovery.append(func.__name__)
+    if '_' in func.__name__:
+        _no_suite_discovery.append(func.__name__.replace("_", "-"))
     return func
 
 

--- a/mx.py
+++ b/mx.py
@@ -749,7 +749,7 @@ def suite_context_free(func):
     """
     Decorator for commands that don't need a primary suite.
     """
-    _suite_context_free.append(func.__name__)
+    _suite_context_free.append(func.__name__.replace("_", "-"))
     return func
 
 # Names of commands that don't need a primary suite but will use one if it can be found.
@@ -761,7 +761,7 @@ def optional_suite_context(func):
     """
     Decorator for commands that don't need a primary suite but will use one if it can be found.
     """
-    _optional_suite_context.append(func.__name__)
+    _optional_suite_context.append(func.__name__.replace("_", "-"))
     return func
 
 # Names of commands that need a primary suite but don't need suites to be loaded.
@@ -4110,7 +4110,7 @@ def download(path, urls, verbose=False, abortOnError=True, verifyOnly=False):
     jarURLPattern = re.compile('jar:(.*)!/(.*)')
     verify_errors = {}
     for url in urls:
-        if not verifyOnly or verbose:
+        if not verifyOnly and verbose:
             log('Downloading ' + url + ' to ' + path)
         m = jarURLPattern.match(url)
         jarEntryName = None
@@ -19245,6 +19245,8 @@ update_commands("mx", {
     'verifysourceinproject': [verifysourceinproject, ''],
     'version': [show_version, ''],
 })
+
+from mx_fetchjdk import fetch_jdk
 
 from mx_unittest import unittest
 from mx_jackpot import jackpot

--- a/mx_commands.py
+++ b/mx_commands.py
@@ -114,6 +114,9 @@ class MxCommands(object):
 class MxCommand(object):
 
     def __init__(self, mx_commands, command_function, suite_name, command, usage_msg='', doc_function=None, props=None):
+        if '_' in command:
+            import mx
+            mx.abort("An mx command cannot contain '_' in its name: {}. Use '-' instead.".format(command))
         self._mx_commands = mx_commands
         self._command_function = command_function
         self.suite_name = suite_name

--- a/mx_commands.py
+++ b/mx_commands.py
@@ -114,9 +114,6 @@ class MxCommands(object):
 class MxCommand(object):
 
     def __init__(self, mx_commands, command_function, suite_name, command, usage_msg='', doc_function=None, props=None):
-        if '_' in command:
-            import mx
-            mx.abort("An mx command cannot contain '_' in its name: {}. Use '-' instead.".format(command))
         self._mx_commands = mx_commands
         self._command_function = command_function
         self.suite_name = suite_name

--- a/mx_fetchjdk.py
+++ b/mx_fetchjdk.py
@@ -1,7 +1,7 @@
 #
 # ----------------------------------------------------------------------------------------------------
 #
-# Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -44,8 +44,8 @@ def fetch_jdk(args):
     """
     args = _parse_fetchjdk_settings(args)
 
-    distribution = args["java_distribution"]
-    jdk_path = args["jdk_path"]
+    distribution = args["java-distribution"]
+    jdk_path = args["jdk-path"]
     jdk_folder = distribution.get_jdk_folder()
     full_jdk_path = distribution.get_full_jdk_path(jdk_path)
     jdk_url = mx_urlrewrites.rewriteurl(distribution.get_url())
@@ -94,11 +94,11 @@ def _parse_fetchjdk_settings(args):
     settings = {}
     settings["quiet"] = False
     settings["keep-archive"] = False
-    settings["jdk_path"] = abspath(join('bin', 'jdks'))
+    settings["jdk-path"] = abspath(join('bin', 'jdks'))
 
     jdk_paths = find_system_jdks()
     if len(jdk_paths) > 0:
-        settings["jdk_path"] = jdk_paths[0]
+        settings["jdk-path"] = jdk_paths[0]
         found_jdk_path = True
     else:
         found_jdk_path = False
@@ -108,10 +108,10 @@ def _parse_fetchjdk_settings(args):
     parser = ArgumentParser(prog='mx fetch-labsjdk')
     parser.add_argument('--java-distribution', action='store', help='JDK distribution which should be downloaded (e.g. "labsjdk-ce-11" or "openjdk8")')
     parser.add_argument('--configuration', action='store', help='location of configuration json file (default: \'{}\')'.format(common_location))
-    parser.add_argument('--to', action='store', help='location where JDK would be downloaded (default: \'{}\')'.format(settings["jdk_path"]))
+    parser.add_argument('--to', action='store', help='location where JDK would be downloaded (default: \'{}\')'.format(settings["jdk-path"]))
     parser.add_argument('--alias', action='store', help='name of symlink to JDK')
-    parser.add_argument('--keep-archive', action='store_true', help='keep downloaded JDK archive (default: {})'.format(settings["keep-archive"]))
-    parser.add_argument('-q', '--quiet', action='store_true', help='suppress logging output (default: {})'.format(settings["quiet"]))
+    parser.add_argument('--keep-archive', action='store_true', help='keep downloaded JDK archive')
+    parser.add_argument('-q', '--quiet', action='store_true', help='suppress logging output')
     parser.add_argument('remainder', nargs=REMAINDER, metavar='...')
     args = parser.parse_args(args)
 
@@ -119,17 +119,17 @@ def _parse_fetchjdk_settings(args):
         settings["quiet"] = args.quiet
 
     if args.to is not None:
-        settings["jdk_path"] = args.to
+        settings["jdk-path"] = args.to
     elif not found_jdk_path and not settings["quiet"]:
-        mx.warn("No standard JDK location. Using {}".format(settings["jdk_path"]))
+        mx.warn("No standard JDK location. Using {}".format(settings["jdk-path"]))
 
     try:
-        test_location = join(settings["jdk_path"], "test")
+        test_location = join(settings["jdk-path"], "test")
         test_file = open(test_location, 'w')
         test_file.close()
         os.remove(test_location)
     except IOError:
-        mx.abort("Path '"+settings["jdk_path"]+"' is not writable. " + os.linesep +
+        mx.abort("Path '"+settings["jdk-path"]+"' is not writable. " + os.linesep +
         "Rerun command with elevated privileges, or choose different JDK download location.")
 
     if args.configuration is not None:
@@ -148,9 +148,9 @@ def _parse_fetchjdk_settings(args):
     JdkDistribution.parse_common_json(common_location)
 
     if args.java_distribution is not None:
-        settings["java_distribution"] = JdkDistribution.by_name(args.java_distribution)
+        settings["java-distribution"] = JdkDistribution.by_name(args.java_distribution)
     else:
-        settings["java_distribution"] = JdkDistribution.choose_dist(settings["quiet"])
+        settings["java-distribution"] = JdkDistribution.choose_dist(settings["quiet"])
 
     if args.keep_archive is not None:
         settings["keep-archive"] = args.keep_archive

--- a/mx_fetchjdk.py
+++ b/mx_fetchjdk.py
@@ -46,15 +46,18 @@ def fetch_jdk(args):
 
     distribution = args["java-distribution"]
     jdk_path = args["jdk-path"]
+    jdk_artifact = distribution.get_jdk_folder()
     full_jdk_path = distribution.get_full_jdk_path(jdk_path)
     jdk_url = mx_urlrewrites.rewriteurl(distribution.get_url())
+    jdk_url_sha = jdk_url + ".sha1"
     jdk_archive = distribution.get_archive()
 
     if not exists(full_jdk_path):
         archive_location = join(jdk_path, jdk_archive)
+        mx._opts.no_download_progress = args["quiet"]
+        sha1_hash = mx._hashFromUrl(jdk_url_sha)
         if not exists(archive_location) or not args["keep-archive"]:
-            mx._opts.no_download_progress = args["quiet"]
-            mx.download(archive_location, [jdk_url], verbose=not args["quiet"])
+            mx.download_file_with_sha1(jdk_artifact, archive_location, [jdk_url], sha1_hash, archive_location + '.sha1', resolve=True, mustExist=True, sources=False)
         untar = mx.TarExtractor(archive_location)
 
         if not args["quiet"]:
@@ -160,7 +163,8 @@ def _parse_fetchjdk_settings(args):
             common_location = join(os.getcwd(), 'common.json') # Fallback to same folder
             if not exists(common_location):
                 common_location = join(_mx_home, 'common.json') # Fallback to mx
-            mx.warn("Selected `{}` as configuration location, since no location is provided".format(common_location))
+            if not settings["quiet"]:
+                mx.warn("Selected `{}` as configuration location, since no location is provided".format(common_location))
     if not exists(common_location):
         mx.abort("Configuration file doesn't exist")
 

--- a/mx_fetchjdk.py
+++ b/mx_fetchjdk.py
@@ -106,7 +106,7 @@ def _parse_fetchjdk_settings(args):
     common_location = join(_mx_home, 'common.json')
 
     parser = ArgumentParser(prog='mx fetch-labsjdk')
-    parser.add_argument('--java-distribution', action='store', help='JDK distribution which should be downloaded (e.g. "labsjdk-ce-11" or "openjdk8")')
+    parser.add_argument('--java-distribution', action='store', help='JDK distribution that should be downloaded (e.g., "labsjdk-ce-11" or "openjdk8")')
     parser.add_argument('--configuration', action='store', help='location of configuration json file (default: \'{}\')'.format(common_location))
     parser.add_argument('--to', action='store', help='location where JDK would be downloaded (default: \'{}\')'.format(settings["jdk-path"]))
     parser.add_argument('--alias', action='store', help='name of symlink to JDK')

--- a/mx_fetchjdk.py
+++ b/mx_fetchjdk.py
@@ -1,0 +1,146 @@
+#
+# ----------------------------------------------------------------------------------------------------
+#
+# Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+# ----------------------------------------------------------------------------------------------------
+#
+import os, shutil
+from os.path import join, relpath, exists, abspath, isdir, islink
+from shutil import copytree
+from argparse import ArgumentParser, PARSER, REMAINDER, Namespace, FileType, HelpFormatter, ArgumentTypeError, RawTextHelpFormatter
+
+from mx import optional_suite_context, _mx_home, command
+from select_jdk import find_system_jdks
+from jdk_distribution_parser import JdkDistribution
+import mx
+
+@command('mx', 'fetch-jdk', '[options]')
+@optional_suite_context
+def fetch_jdk(args):
+    """fetches required JDK version
+
+    If called without --quiet flag, menu will be printed for available JDK selection.
+    """
+    args = _parse_fetchjdk_settings(args)
+
+    distribution = args["java_distribution"]
+    jdk_path = args["jdk_path"]
+    jdk_folder = distribution.get_jdk_folder()
+    full_jdk_path = distribution.get_full_jdk_path(jdk_path)
+    jdk_url = distribution.get_url()
+    jdk_archive = distribution.get_archive()
+
+    if not exists(full_jdk_path):
+        mx._opts.no_download_progress = args["quiet"]
+        mx.download(join(jdk_path, jdk_archive), [jdk_url], verbose=not args["quiet"])
+        untar = mx.TarExtractor(join(jdk_path, jdk_archive))
+
+        if not args["quiet"]:
+            print("Installing...")
+
+        with untar._open() as tar_file:
+            curr_full_jdk_path = untar._getnames(tar_file)[0]
+
+        untar.extract(jdk_path)
+        if not args["keep-archive"]:
+            os.remove(join(jdk_path, jdk_archive))
+        os.rename(join(jdk_path, curr_full_jdk_path), full_jdk_path)
+
+    if mx.get_os() == 'darwin':
+        full_jdk_path = join(full_jdk_path, 'Contents', 'Home')
+
+    if "alias" in args:
+        alias_full_path = join(jdk_path, args["alias"])
+        if exists(alias_full_path) or islink(alias_full_path):
+            if isdir(alias_full_path) and not islink(alias_full_path):
+                shutil.rmtree(alias_full_path)
+            else:
+                os.remove(alias_full_path)
+
+        if not (mx.is_windows() or mx.is_cygwin()):
+            os.symlink(jdk_folder, alias_full_path)
+        else:
+            copytree(full_jdk_path, alias_full_path, symlinks=True) # fallback for windows
+        full_jdk_path = alias_full_path
+
+    if not args["quiet"]:
+        print("Run the following to set JAVA_HOME in your shell:")
+
+    print('export JAVA_HOME={}'.format(abspath(full_jdk_path)))
+
+
+def _parse_fetchjdk_settings(args):
+    parser = ArgumentParser(prog='mx fetch-labsjdk')
+    parser.add_argument('--java-distribution', action='store', help='JDK distribution which should be downloaded')
+    parser.add_argument('--configuration', action='store', help='location of configuration json file')
+    parser.add_argument('--to', action='store', help='location where JDK would be downloaded')
+    parser.add_argument('--alias', action='store', help='name of symlink to JDK')
+    parser.add_argument('--keep-archive', action='store_true', help='keep downloaded JDK archive')
+    parser.add_argument('-q', '--quiet', action='store_true', help='suppress logging output')
+    parser.add_argument('remainder', nargs=REMAINDER, metavar='...')
+    args = parser.parse_args(args)
+
+    settings = {}
+    settings["jdk_path"] = join('bin', 'jdks')
+    settings["quiet"] = False
+    settings["keep-archive"] = False
+
+    if args.quiet is not None:
+        settings["quiet"] = args.quiet
+
+    if args.configuration is not None:
+        common_location = args.configuration
+    else:
+        if mx.primary_suite() is not None:
+            common_location = join(mx.primary_suite().vc_dir, 'common.json') # Try fetching suite config
+        else:
+            common_location = join(os.getcwd(), 'common.json') # Fallback to same folder 
+            if not exists(common_location):
+                common_location = join(_mx_home, 'common.json') # Fallback to mx
+            mx.warn("Selected `{}` as configuration location, since no location is provided".format(common_location))
+    if not exists(common_location):
+            mx.abort("Configuration file doesn't exist")
+
+    JdkDistribution.parse_common_json(common_location)
+
+    if args.java_distribution is not None:
+        settings["java_distribution"] = JdkDistribution.by_name(args.java_distribution)
+    else:
+        settings["java_distribution"] = JdkDistribution.choose_dist(settings["quiet"])
+
+    if args.keep_archive is not None:
+        settings["keep-archive"] = args.keep_archive
+
+    if args.to is not None:
+        settings["jdk_path"] = args.to
+    else:
+        jdk_paths = find_system_jdks()
+        if len(jdk_paths) > 0:
+            settings["jdk_path"] = jdk_paths[0]
+        elif not settings["quiet"]:
+            mx.warn("No standard JDK location. Using {}".format(settings["jdk_path"]))
+    
+    if args.alias is not None:
+        settings["alias"] = args.alias
+
+    return settings

--- a/mx_fetchjdk.py
+++ b/mx_fetchjdk.py
@@ -79,7 +79,7 @@ def fetch_jdk(args):
     elif not args["quiet"]:
         mx.warn("Requested JDK was already present")
 
-    if mx.is_darwin():
+    if mx.is_darwin() and exists(join(full_jdk_path, 'Contents', 'Home')):
         if args["strip-contents-home"]:
             tmp_full_jdk_path = full_jdk_path + ".tmp"
             shutil.move(full_jdk_path, tmp_full_jdk_path)

--- a/mx_fetchjdk.py
+++ b/mx_fetchjdk.py
@@ -91,6 +91,7 @@ def fetch_jdk(args):
             mx.warn("The --keep-archive option is ignored when the JDK is already installed.")
         mx.log("Requested JDK is already installed at {}".format(final_path))
 
+    curr_path = final_path
     if mx.is_darwin() and exists(join(final_path, 'Contents', 'Home')):
         if args["strip-contents-home"]:
             tmp_path = final_path + ".tmp"
@@ -109,9 +110,9 @@ def fetch_jdk(args):
                 os.remove(alias_full_path)
 
         if not (mx.is_windows() or mx.is_cygwin()):
-            os.symlink(final_path, alias_full_path)
+            os.symlink(curr_path, alias_full_path)
         else:
-            copytree(final_path, alias_full_path, symlinks=True) # fallback for windows
+            copytree(curr_path, alias_full_path, symlinks=True) # fallback for windows
         final_path = alias_full_path
 
     if not args["quiet"]:

--- a/mx_fetchjdk.py
+++ b/mx_fetchjdk.py
@@ -24,10 +24,11 @@
 #
 # ----------------------------------------------------------------------------------------------------
 #
+from __future__ import print_function
 import os, shutil
-from os.path import join, relpath, exists, abspath, isdir, islink
+from os.path import join, exists, abspath, isdir, islink
 from shutil import copytree
-from argparse import ArgumentParser, PARSER, REMAINDER, Namespace, FileType, HelpFormatter, ArgumentTypeError, RawTextHelpFormatter
+from argparse import ArgumentParser, REMAINDER
 
 from mx import optional_suite_context, _mx_home, command
 from select_jdk import find_system_jdks
@@ -114,12 +115,12 @@ def _parse_fetchjdk_settings(args):
         if mx.primary_suite() is not None:
             common_location = join(mx.primary_suite().vc_dir, 'common.json') # Try fetching suite config
         else:
-            common_location = join(os.getcwd(), 'common.json') # Fallback to same folder 
+            common_location = join(os.getcwd(), 'common.json') # Fallback to same folder
             if not exists(common_location):
                 common_location = join(_mx_home, 'common.json') # Fallback to mx
             mx.warn("Selected `{}` as configuration location, since no location is provided".format(common_location))
     if not exists(common_location):
-            mx.abort("Configuration file doesn't exist")
+        mx.abort("Configuration file doesn't exist")
 
     JdkDistribution.parse_common_json(common_location)
 
@@ -139,7 +140,7 @@ def _parse_fetchjdk_settings(args):
             settings["jdk_path"] = jdk_paths[0]
         elif not settings["quiet"]:
             mx.warn("No standard JDK location. Using {}".format(settings["jdk_path"]))
-    
+
     if args.alias is not None:
         settings["alias"] = args.alias
 

--- a/mx_fetchjdk.py
+++ b/mx_fetchjdk.py
@@ -32,7 +32,7 @@ from argparse import ArgumentParser, PARSER, REMAINDER, Namespace, FileType, Hel
 from mx import optional_suite_context, _mx_home, command
 from select_jdk import find_system_jdks
 from jdk_distribution_parser import JdkDistribution
-import mx
+import mx, mx_urlrewrites
 
 @command('mx', 'fetch-jdk', '[options]')
 @optional_suite_context
@@ -47,7 +47,7 @@ def fetch_jdk(args):
     jdk_path = args["jdk_path"]
     jdk_folder = distribution.get_jdk_folder()
     full_jdk_path = distribution.get_full_jdk_path(jdk_path)
-    jdk_url = distribution.get_url()
+    jdk_url = mx_urlrewrites.rewriteurl(distribution.get_url())
     jdk_archive = distribution.get_archive()
 
     if not exists(full_jdk_path):

--- a/mx_fetchjdk.py
+++ b/mx_fetchjdk.py
@@ -51,7 +51,13 @@ def fetch_jdk(args):
     jdk_url_sha = jdk_url + ".sha1"
     jdk_archive = distribution.get_archive()
 
+    if not args["quiet"] and not mx.ask_yes_no("Install {} to {}".format(jdk_artifact, jdk_path), default='y'):
+            mx.abort("JDK installation canceled")
+
     if not exists(full_jdk_path):
+        if not args["quiet"]:
+            print("Fetching {} archive...".format(jdk_artifact))
+
         archive_location = join(jdk_path, jdk_archive)
         mx._opts.no_download_progress = args["quiet"]
         try:
@@ -143,7 +149,8 @@ def _parse_fetchjdk_settings(args):
         warning_msg = "Path '{}' is not writable (try running with elevated privileges). ".format(settings["jdk-path"])
         settings["jdk-path"] = abspath(join("bin", "jdks"))
         warning_msg += os.linesep + "Trying to fall back to {}".format(settings["jdk-path"])
-        mx.warn(warning_msg)
+        if not settings["quiet"]:
+            mx.warn(warning_msg)
         if not check_access_jdk_path(settings["jdk-path"]):
             mx.abort("Path '{}' is not writable (try running with elevated privileges). ".format(settings["jdk-path"]))
 

--- a/mx_fetchjdk.py
+++ b/mx_fetchjdk.py
@@ -52,7 +52,7 @@ def fetch_jdk(args):
     jdk_archive = distribution.get_archive()
 
     if not args["quiet"] and not mx.ask_yes_no("Install {} to {}".format(jdk_artifact, jdk_path), default='y'):
-            mx.abort("JDK installation canceled")
+        mx.abort("JDK installation canceled")
 
     if not exists(full_jdk_path):
         if not args["quiet"]:

--- a/mx_fetchjdk.py
+++ b/mx_fetchjdk.py
@@ -46,7 +46,6 @@ def fetch_jdk(args):
 
     distribution = args["java-distribution"]
     jdk_path = args["jdk-path"]
-    jdk_folder = distribution.get_jdk_folder()
     full_jdk_path = distribution.get_full_jdk_path(jdk_path)
     jdk_url = mx_urlrewrites.rewriteurl(distribution.get_url())
     jdk_archive = distribution.get_archive()
@@ -77,7 +76,7 @@ def fetch_jdk(args):
 
     if mx.is_darwin():
         if args["strip-contents-home"]:
-            tmp_full_jdk_path =  full_jdk_path + ".tmp"
+            tmp_full_jdk_path = full_jdk_path + ".tmp"
             os.rename(full_jdk_path, tmp_full_jdk_path)
             shutil.move(join(tmp_full_jdk_path, 'Contents', 'Home'), full_jdk_path)
             shutil.rmtree(tmp_full_jdk_path)
@@ -182,8 +181,8 @@ def _parse_fetchjdk_settings(args):
     return settings
 
 def parse_common_json(common_path):
-        with open(common_path) as common_file:
-            common_cfg = json.load(common_file)
+    with open(common_path) as common_file:
+        common_cfg = json.load(common_file)
 
-        for distribution in common_cfg["jdks"]:
-            JdkDistribution.parse(distribution, common_cfg["jdks"][distribution]["version"])
+    for distribution in common_cfg["jdks"]:
+        JdkDistribution.parse(distribution, common_cfg["jdks"][distribution]["version"])

--- a/mx_fetchjdk.py
+++ b/mx_fetchjdk.py
@@ -66,6 +66,8 @@ def fetch_jdk(args):
         if not args["keep-archive"]:
             os.remove(join(jdk_path, jdk_archive))
         os.rename(join(jdk_path, curr_full_jdk_path), full_jdk_path)
+    elif not args["quiet"]:
+        mx.warn("Requested JDK was already present")
 
     if mx.get_os() == 'darwin':
         full_jdk_path = join(full_jdk_path, 'Contents', 'Home')
@@ -124,11 +126,13 @@ def _parse_fetchjdk_settings(args):
         mx.warn("No standard JDK location. Using {}".format(settings["jdk-path"]))
 
     try:
+        if not exists(settings["jdk-path"]):
+            os.makedirs(settings["jdk-path"])
         test_location = join(settings["jdk-path"], "test")
         test_file = open(test_location, 'w')
         test_file.close()
         os.remove(test_location)
-    except IOError:
+    except (IOError, OSError):
         mx.abort("Path '"+settings["jdk-path"]+"' is not writable. " + os.linesep +
         "Rerun command with elevated privileges, or choose different JDK download location.")
 

--- a/mx_fetchjdk.py
+++ b/mx_fetchjdk.py
@@ -51,9 +51,11 @@ def fetch_jdk(args):
     jdk_archive = distribution.get_archive()
 
     if not exists(full_jdk_path):
-        mx._opts.no_download_progress = args["quiet"]
-        mx.download(join(jdk_path, jdk_archive), [jdk_url], verbose=not args["quiet"])
-        untar = mx.TarExtractor(join(jdk_path, jdk_archive))
+        archive_location = join(jdk_path, jdk_archive)
+        if not exists(archive_location) or not args["keep-archive"]:
+            mx._opts.no_download_progress = args["quiet"]
+            mx.download(archive_location, [jdk_url], verbose=not args["quiet"])
+        untar = mx.TarExtractor(archive_location)
 
         if not args["quiet"]:
             print("Installing...")
@@ -77,7 +79,7 @@ def fetch_jdk(args):
     if mx.is_darwin():
         if args["strip-contents-home"]:
             tmp_full_jdk_path = full_jdk_path + ".tmp"
-            os.rename(full_jdk_path, tmp_full_jdk_path)
+            shutil.move(full_jdk_path, tmp_full_jdk_path)
             shutil.move(join(tmp_full_jdk_path, 'Contents', 'Home'), full_jdk_path)
             shutil.rmtree(tmp_full_jdk_path)
         else:

--- a/mx_fetchjdk.py
+++ b/mx_fetchjdk.py
@@ -55,7 +55,10 @@ def fetch_jdk(args):
     if not exists(full_jdk_path):
         archive_location = join(jdk_path, jdk_archive)
         mx._opts.no_download_progress = args["quiet"]
-        sha1_hash = mx._hashFromUrl(jdk_url_sha)
+        try:
+            sha1_hash = mx._hashFromUrl(jdk_url_sha)
+        except:
+            mx.abort("Error fetching sha1 hash, check your download location")
         if not exists(archive_location) or not args["keep-archive"]:
             mx.download_file_with_sha1(jdk_artifact, archive_location, [jdk_url], sha1_hash, archive_location + '.sha1', resolve=True, mustExist=True, sources=False)
         untar = mx.TarExtractor(archive_location)


### PR DESCRIPTION
Adds `mx fetch-labsjdk` command to `mx` which downloads JDK required for project building and outputs corresponding JAVA_HOME export command to stdout. 
```
$ mx fetch-jdk --help
usage: mx fetch-labsjdk [-h] [--java-distribution JAVA_DISTRIBUTION]
                        [--configuration CONFIGURATION] [--to TO]
                        [--alias ALIAS] [--keep-archive] [-q]
                        ...

optional arguments:
  -h, --help            show this help message and exit
  --java-distribution JAVA_DISTRIBUTION
                        JDK distribution which should be downloaded
  --configuration CONFIGURATION
                        location of configuration json file
  --to TO               location where JDK would be downloaded
  --alias ALIAS         name of symlink to JDK
  --keep-archive        keep downloaded JDK archive
  -q, --quiet           suppress logging output
```
If command is ran without `quiet` and `java-distribution` flags, interactive menu would be displayed.

Additional suites can register their own JDK distributions in their mx extensions, like:
```python
from jdk_distribution_parser import JdkDistribution

class LabsJDKEE(JdkDistribution):
    _name = "labsjdk-ee-11"
    def __init__(self, version):
        JdkDistribution.__init__(self, version)
        machine = mx.get_os() + '-' + mx.get_arch()
        self._filename = "labsjdk-{}-{}".format(version, machine)
        self._short_version = version
        self._archive = "{}.tar.gz".format(self._filename)
        self._url = "http://example.com/{}".format(self._archive)

JdkDistribution._DEFAULT_JDK = "labsjdk-ee-11"
```