### PR TITLE
Avoid broken symlinks in fetch-jdk by using absolute path

### DIFF
--- a/mx_fetchjdk.py
+++ b/mx_fetchjdk.py
@@ -110,7 +110,7 @@ def fetch_jdk(args):
                 os.remove(alias_full_path)
 
         if not (mx.is_windows() or mx.is_cygwin()):
-            os.symlink(curr_path, alias_full_path)
+            os.symlink(abspath(curr_path), alias_full_path)
         else:
             copytree(curr_path, alias_full_path, symlinks=True) # fallback for windows
         final_path = alias_full_path


### PR DESCRIPTION
If `--to` is set to relative location, and `--alias` option is set, resulting symlink would be broken if accessed as absolute path.