### PR TITLE
Travis test running mx in a non-version-controlled directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,25 @@ addons:
   apt:
     packages:
       - openjdk-8-jdk
-install:
-  - pip install pylint==2.4
-  - pylint --version
-  - |
-      export ECLIPSE_TAR=$TRAVIS_BUILD_DIR/../eclipse.tar.gz
-      wget https://archive.eclipse.org/eclipse/downloads/drops4/R-4.5.2-201602121500/eclipse-SDK-4.5.2-linux-gtk-x86_64.tar.gz -O $ECLIPSE_TAR
-      tar -C $TRAVIS_BUILD_DIR/.. -xf $ECLIPSE_TAR
-      export ECLIPSE_EXE=$TRAVIS_BUILD_DIR/../eclipse/eclipse
-      export JDT=$TRAVIS_BUILD_DIR/ecj.jar
-      wget https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.5.2-201602121500/ecj-4.5.2.jar -O $JDT
-script: ./mx --strict-compliance gate --strict-mode
+jobs:
+  - name: "mx gate"
+    install:
+      - pip install pylint==2.4
+      - pylint --version
+      - |
+          export ECLIPSE_TAR=$TRAVIS_BUILD_DIR/../eclipse.tar.gz
+          wget https://archive.eclipse.org/eclipse/downloads/drops4/R-4.5.2-201602121500/eclipse-SDK-4.5.2-linux-gtk-x86_64.tar.gz -O $ECLIPSE_TAR
+          tar -C $TRAVIS_BUILD_DIR/.. -xf $ECLIPSE_TAR
+          export ECLIPSE_EXE=$TRAVIS_BUILD_DIR/../eclipse/eclipse
+          export JDT=$TRAVIS_BUILD_DIR/ecj.jar
+          wget https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.5.2-201602121500/ecj-4.5.2.jar -O $JDT
+    script: ./mx --strict-compliance gate --strict-mode
+  - name: "mx in non VCS-managed directory"
+    install:
+      - |
+          wget https://github.com/oracle/graal/archive/master.zip -O $TRAVIS_BUILD_DIR/../master.zip
+          unzip -d $TRAVIS_BUILD_DIR/.. $TRAVIS_BUILD_DIR/../master.zip
+    script:
+      - |
+          cd $TRAVIS_BUILD_DIR/../graal-master/compiler
+          $TRAVIS_BUILD_DIR/mx help


### PR DESCRIPTION
mx fails to build a suite that is not and version control however, this
is often desired in CI/CD environments (see https://github.com/graalvm/mx/issues/131).

As suggested in
https://github.com/graalvm/mx/issues/131#issuecomment-294284867 this
commit adds a test for the above case.