### PR TITLE
Allow java debug port to use remote addresses

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -520,7 +520,7 @@ environment variables:
         self.add_argument('-y', action='store_const', const='y', dest='answer', help='answer \'y\' to all questions asked')
         self.add_argument('-n', action='store_const', const='n', dest='answer', help='answer \'n\' to all questions asked')
         self.add_argument('-p', '--primary-suite-path', help='set the primary suite directory', metavar='<path>')
-        self.add_argument('--dbg', type=int, dest='java_dbg_port', help='make Java processes wait on <port> for a debugger', metavar='<port>')
+        self.add_argument('--dbg', dest='java_dbg_port', help='make Java processes wait on [<address>:]<port> for a debugger', metavar='[<address>:]<port>')
         self.add_argument('-d', action='store_const', const=8000, dest='java_dbg_port', help='alias for "-dbg 8000"')
         self.add_argument('--attach', dest='attach', help='Connect to existing server running at [<address>:]<port>')
         self.add_argument('--backup-modified', action='store_true', help='backup generated files if they pre-existed and are modified')


### PR DESCRIPTION
When your IDE is running on a different machine to the JVM then
the debug port needs to be given as hostname:port, or just *:port
to allow any machine to connect.

However, mx requires the dbg-port argument to be an integer.
Simply remove this requirement, allowing, for example:
   mx --dbg *:8000 unittest mytest