### PR TITLE
Fix AttributeError: LinesOutputCapture instance has no attribute 'data'

### DIFF
--- a/mx_native.py
+++ b/mx_native.py
@@ -132,7 +132,7 @@ class Ninja(object):
             os.chmod(self.binary, 0o755)
             self._run(*args, **kwargs)  # retry
         else:
-            not rc or mx.abort(rc if mx.get_opts().verbose else out.data)  # pylint: disable=expression-not-assigned
+            not rc or mx.abort(rc if mx.get_opts().verbose else out.lines)  # pylint: disable=expression-not-assigned
 
 
 class NativeDependency(mx.Dependency):


### PR DESCRIPTION
mx/mx_native.py:135 references a non-existing `data` attribute of the `LinesOutputCapture` object.

This causes:
```
...
Building com.oracle.svm.native.jvm.posix_amd64 with Ninja... [dependencies were added, removed or re-ordered]
Process Process-308:
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 267, in _bootstrap
    self.run()
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/mnt/shared/AoTandSCONE/scripts/graal/mx/mx.py", line 13778, in executeTask
    task.execute()
  File "/mnt/shared/AoTandSCONE/scripts/graal/mx/mx.py", line 4794, in execute
    buildNeeded, reason = self.needsBuild(newestInput)
  File "/mnt/shared/AoTandSCONE/scripts/graal/mx/mx_native.py", line 373, in needsBuild
    is_needed, self._reason = self.ninja.needs_build()
  File "/mnt/shared/AoTandSCONE/scripts/graal/mx/mx_native.py", line 99, in needs_build
    self._run('-n', '-d', 'explain', out=out, err=details)
  File "/mnt/shared/AoTandSCONE/scripts/graal/mx/mx_native.py", line 135, in _run
    not rc or mx.abort(rc if mx.get_opts().verbose else out.data)  # pylint: disable=expression-not-assigned
AttributeError: LinesOutputCapture instance has no attribute 'data'
Building com.oracle.svm.native.libchelper_amd64 with Ninja failed
1 build tasks failed
```

Change `not rc or mx.abort(rc if mx.get_opts().verbose else out.data)` in `not rc or mx.abort(rc if mx.get_opts().verbose else out.lines)` to fix it.

Better yet, print an actually useful error message with the command that caused the failure. Something like `print(cmd, self.build_dir)`.