### PR TITLE
Linux-musl support

### DIFF
--- a/mx.mx/suite.py
+++ b/mx.mx/suite.py
@@ -519,6 +519,12 @@ suite = {
             "optional" : True
           }
         },
+        "linux-musl" : {
+          "amd64" : {
+            "urls" : ["https://download.bell-sw.com/graalvm/ninja-1.10.1-x86_64-linux-musl.zip"],
+            "sha1" : "0f3d92566d116edc06e7a983ec1bbc4d4a9e9c2d"
+          }
+        },
         "darwin" : {
           "amd64" : {
             "urls" : ["https://github.com/ninja-build/ninja/releases/download/v{version}/ninja-mac.zip"],

--- a/mx.py
+++ b/mx.py
@@ -3853,7 +3853,7 @@ def get_os():
     Get a canonical form of sys.platform.
     """
     global _os
-    if not _os:
+    if _os is None:
         _os = _get_os()
         if _opts and _opts.verbose:
             log('OS detected: %s' % _os)

--- a/mx.py
+++ b/mx.py
@@ -2176,9 +2176,11 @@ class Suite(object):
     def _pop_os_arch(attrs, context):
         os_arch = attrs.pop('os_arch', None)
         if os_arch:
-            os_key = get_os_variant()
-            if not os_key in os_arch and '-' in os_key:
-                os_key = os_key.split('-')[0]
+            os_key = None
+            if get_os_variant():
+                os_key = get_os() + '-' + get_os_variant()
+            if os_key is None or not os_key in os_arch:
+                os_key = get_os()
             if not os_key in os_arch:
                 os_key = '<others>'
             os_attrs = os_arch.pop(os_key, None)
@@ -2191,7 +2193,7 @@ class Suite(object):
                 else:
                     warn("No platform-specific definition is available for {} for your architecture ({})".format(context, get_arch()))
             else:
-                warn("No platform-specific definition is available for {} for your OS ({})".format(context, get_os_variant()))
+                warn("No platform-specific definition is available for {} for your OS ({})".format(context, get_os()))
         return None
 
     @staticmethod
@@ -3854,11 +3856,12 @@ _os_variant = None
 def get_os_variant():
     global _os_variant
     if _os_variant is None:
-        _os_variant = get_os()
-        if _os_variant == 'linux' and 'musl' in _check_output_str(['ldd', sys.executable]):
-            _os_variant = 'linux-musl'
+        if get_os() == 'linux' and 'musl' in _check_output_str(['ldd', sys.executable]):
+            _os_variant = 'musl'
+        else:
+            _os_variant = ''
         if _opts and _opts.verbose:
-            log('OS detected: %s' % _os_variant)
+            log('OS variant detected: %s' % (_os_variant if _os_variant else 'none'))
     return _os_variant
 
 

--- a/mx.py
+++ b/mx.py
@@ -2179,9 +2179,9 @@ class Suite(object):
             os_key = None
             if get_os_variant():
                 os_key = get_os() + '-' + get_os_variant()
-            if os_key is None or not os_key in os_arch:
+            if os_key is None or os_key not in os_arch:
                 os_key = get_os()
-            if not os_key in os_arch:
+            if os_key not in os_arch:
                 os_key = '<others>'
             os_attrs = os_arch.pop(os_key, None)
             if os_attrs:

--- a/mx.py
+++ b/mx.py
@@ -3826,14 +3826,14 @@ def is_cygwin():
     return sys.platform.startswith('cygwin')
 
 
-def get_os():
-    """
-    Get a canonical form of sys.platform.
-    """
+def _get_os():
     if is_darwin():
         return 'darwin'
     elif is_linux():
-        return 'linux'
+        if 'musl' in _check_output_str(['ldd', sys.executable]):
+            return 'linux-musl'
+        else:
+            return 'linux'
     elif is_openbsd():
         return 'openbsd'
     elif is_sunos():
@@ -3844,6 +3844,20 @@ def get_os():
         return 'cygwin'
     else:
         abort('Unknown operating system ' + sys.platform)
+
+
+_os = None
+
+def get_os():
+    """
+    Get a canonical form of sys.platform.
+    """
+    global _os
+    if not _os:
+        _os = _get_os()
+        if _opts and _opts.verbose:
+            log('OS detected: %s' % _os)
+    return _os
 
 
 def _is_process_alive(p):

--- a/mx.py
+++ b/mx.py
@@ -3860,8 +3860,7 @@ def get_os_variant():
             _os_variant = 'musl'
         else:
             _os_variant = ''
-        if _opts and _opts.verbose:
-            log('OS variant detected: %s' % (_os_variant if _os_variant else 'none'))
+        logv('OS variant detected: {}'.format(_os_variant if _os_variant else 'none'))
     return _os_variant
 
 


### PR DESCRIPTION
This patch adds support for musl-based Linux distros such as Alpine. This is needed in order to enable musl-based GraalVM builds.

I've chosen rather simple approach and just introduced a new `os_arch`: `linux-musl`. It is detected by parsing `ldd` output. Because it's more costly than just examining `sys.platform`, the result is cached in a global var. This new arch type is used right away in `suite.py` to define musl-based Ninja binary.

This solution is mostly backward compatible, I don't expect it to break many existing projects. Builds may start failing when run on musl-based Linux (because the `linux-musl` key is lacking), but they would have failed anyway later when they try to execute glibc-based binaries they'd have downloaded from the `linux` section.