### PR TITLE
Use explicit encoding for reading from file.

### DIFF
--- a/mx_ide_eclipse.py
+++ b/mx_ide_eclipse.py
@@ -130,7 +130,7 @@ def eclipseformat(args):
     class FileInfo:
         def __init__(self, path):
             self.path = path
-            with open(path) as fp:
+            with open(path, encoding='utf-8') as fp:
                 self.content = fp.read()
             self.times = (os.path.getatime(path), mx.getmtime(path))
 


### PR DESCRIPTION
open() without encoding uses platform default encoding. On WIndows it can be encoding which has some bytes undefined - for example Windows-1250 don't know 0x88.