### PR TITLE
Add fetch-jdk to the list of _optional_suite_context commands

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -807,7 +807,7 @@ def suite_context_free(func):
 
 # Names of commands that don't need a primary suite but will use one if it can be found.
 # This cannot be used outside of mx because of implementation restrictions
-_optional_suite_context = ['help', 'paths']
+_optional_suite_context = ['help', 'paths', 'fetch-jdk']
 
 
 def optional_suite_context(func):


### PR DESCRIPTION
This allows invoking `mx fetch-jdk` from a freshly cloned graal repo.

e.g.

```
git clone --depth 1 git@github.com:graalvm/mx
git clone --depth 1 git@github.com:oracle/graal.git
cd graal
mkdir jdk-dl
../mx/mx fetch-jdk --jdk-id openjdk8 --to jdk-dl
```