### PR TITLE
Add detection of `python3` binary.

### DIFF
--- a/mx
+++ b/mx
@@ -60,7 +60,18 @@ else
         if [ $? -eq 0 ]; then
             python_exe=python2
         else
-            python_exe=python
+            type python > /dev/null 2>&1
+            if [ $? -eq 0 ]; then
+                python_exe=python
+            else
+                type python3 > /dev/null 2>&1
+                if [ $? -eq 0 ]; then
+                    python_exe=python3
+                else
+                    echo "Cannot find Python on PATH"
+                    exit 1
+                fi
+            fi
         fi
     fi
 fi


### PR DESCRIPTION
Python 2 is being or has been phased out of default installations on many systems. [PEP 394](https://legacy.python.org/dev/peps/pep-0394/) means systems such as Ubuntu will not alias `python3` to `python` by default. In order to use the Python 3 binary with mx, the end user must either set `MX_PYTHON=python3`, `MX_PYTHON_VERSION=3`, or set up an alias by some other means. It would be helpful if mx checked if `python3` exists and use it, as part of its existing executable search.

This should maintain full backwards-compatibility. The `python3` binary is only chosen if `python2.7`, `python2`, and `python` do not exist.