### PR TITLE
[GR-37095] Adds ability to create jar entries for directories

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -17886,7 +17886,7 @@ def main():
 
 
 # The version must be updated for every PR (checked in CI)
-version = VersionSpec("5.318.0")  # GR-36869
+version = VersionSpec("5.319.0")  # GR-37095
 
 currentUmask = None
 _mx_start_datetime = datetime.utcnow()

--- a/mx_jardistribution.py
+++ b/mx_jardistribution.py
@@ -999,8 +999,14 @@ class _ArchiveStager(object):
                 for root, _, files in os.walk(outputDir):
                     reldir = root[len(outputDir) + 1:]
                     for f in files:
-                        relpath = join(reldir, f)
-                        self.add_file(dep, outputDir, relpath, archivePrefix, arcnameCheck=overlay_check, includeServices=includeServices)
+                        # If the directory contains a special file named .mxkeep then add a file entry for it
+                        # This was added for the needs of https://github.com/oracle/graal/pull/4327
+                        if f == ".mxkeep":
+                            dirEntry = reldir.replace(os.sep, '/') + '/'
+                            self.bin_archive.entries[dirEntry] = dirEntry
+                        else:
+                            relpath = join(reldir, f)
+                            self.add_file(dep, outputDir, relpath, archivePrefix, arcnameCheck=overlay_check, includeServices=includeServices)
 
             add_classes(archivePrefix, includeServices=True)
             sourceDirs = p.source_dirs()


### PR DESCRIPTION
Just create an `.mxkeep` file in a directory and any jar distribution
containing this directory will include a jar entry for it. The `.mxkeep`
file will not be included.