### PR TITLE
Made `_stage_file_impl` handle both files and directories

### DIFF
--- a/mx_jardistribution.py
+++ b/mx_jardistribution.py
@@ -1434,7 +1434,10 @@ def _stage_file_impl(src, dst):
     if not mx.can_symlink():
         if exists(dst):
             mx.rmtree(dst)
-        shutil.copy(src, dst)
+        if isdir(src):
+            shutil.copytree(src, dst)
+        else:
+            shutil.copy(src, dst)
     else:
         if exists(dst):
             if islink(dst):


### PR DESCRIPTION
Fix for #258:
Replaced `shutil.copy` with a `copytree/copy` combo. On Windows, the error is gone, on Linux, builds work as usual.