### PR TITLE
[GR-41359] Ninja: Use relativ path for project path, so that `-fdebug-prefix-map=` doesn't mess up the file name attribute

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -18096,7 +18096,7 @@ def main():
         abort(1, killsig=signal.SIGINT)
 
 # The version must be updated for every PR (checked in CI)
-version = VersionSpec("6.9.2")   # Add Xcode14 ObjC build workaround
+version = VersionSpec("6.9.3")   # Ninja: Use relativ path for project root
 
 currentUmask = None
 _mx_start_datetime = datetime.utcnow()


### PR DESCRIPTION
This will change the gcc invocation from:
```
$ gcc [...] \
    -fdebug-prefix-map=/home/lewurm/work/graal=/graal \
    -fdebug-prefix-map=/home/lewurm/.mx/jdks/labsjdk-ce-17-jvmci-22.3-b02=labsjdk-ce-17-jvmci-22.3-b02 \
    [...] \
    /home/lewurm/work/graal/substratevm/src/com.oracle.svm.native.libchelper/src/cpuid.c \
    -o src/cpuid.o
```

to

```
$ gcc [...] \
    -fdebug-prefix-map=/home/lewurm/work/graal=graal \
    -fdebug-prefix-map=/home/lewurm/.mx/jdks/labsjdk-ce-17-jvmci-22.3-b02=labsjdk-ce-17-jvmci-22.3-b02 \
    [...] \
    ../../../../src/com.oracle.svm.native.libchelper/src/cpuid.c \
    -o src/cpuid.o
```

And this is how the DWARF information changes, before:
```
$
[...]
0x0000000b: DW_TAG_compile_unit
              DW_AT_name    ("graal/substratevm/src/com.oracle.svm.native.libchelper/src/cpuid.c")
              DW_AT_comp_dir    ("graal/substratevm/mxbuild/darwin-aarch64/com.oracle.svm.native.libchelper/aarch64")
[...]
0x00000032:   DW_TAG_subprogram
                DW_AT_low_pc    (0x00000000000000b8)
                DW_AT_high_pc   (0x0000000000000228)
                DW_AT_name  ("checkCPUFeatures")
                DW_AT_decl_file ("graal/substratevm/mxbuild/darwin-aarch64/com.oracle.svm.native.libchelper/aarch64/graal/substratevm/src/com.oracle.svm.native.libchelper/src/cpuid.c")
                DW_AT_decl_line (772)
```

After:
```
$
[...]
0x0000000b: DW_TAG_compile_unit
              DW_AT_name    ("../../../../src/com.oracle.svm.native.libchelper/src/cpuid.c")
              DW_AT_comp_dir    ("graal/substratevm/mxbuild/darwin-aarch64/com.oracle.svm.native.libchelper/aarch64")
[...]
0x00000032:   DW_TAG_subprogram
                DW_AT_low_pc    (0x00000000000000b8)
                DW_AT_high_pc   (0x0000000000000228)
                DW_AT_name  ("checkCPUFeatures")
                DW_AT_decl_file ("graal/substratevm/mxbuild/darwin-aarch64/com.oracle.svm.native.libchelper/aarch64/../../../../src/com.oracle.svm.native.libchelper/src/cpuid.c")
                DW_AT_decl_line (772)
[...]
```

For what it's worth `gdb` is able to deal with it (it seems to fallsback to `DW_AT_name` if `DW_AT_decl_file` does not exist, see strace log below), but lldb needs a proper path for `DW_AT_decl_file`.

strace output of `gdb`, before:
```
newfstatat(AT_FDCWD, "graal/substratevm/mxbuild/linux-aarch64/com.oracle.svm.native.libchelper/aarch64/graal/substratevm/src/com.oracle.svm.native.libchelper/src/cpuid.c", 0xfffffc3b5228, 0) = -1 ENOENT (No such file or directory)
newfstatat(AT_FDCWD, "/home/lewurm/work/graal/substratevm/src/com.oracle.svm.native.libchelper/src/cpuid.c", {st_mode=S_IFREG|0664, st_size=25615, ...}, 0) = 0
openat(AT_FDCWD, "/home/lewurm/work/graal/substratevm/src/com.oracle.svm.native.libchelper/src/cpuid.c", O_RDONLY|O_CLOEXEC) = 12
```

After:
```
newfstatat(AT_FDCWD, "graal/substratevm/mxbuild/linux-aarch64/com.oracle.svm.native.libchelper/aarch64/../../../../src/com.oracle.svm.native.libchelper/src/cpuid.c", {st_mode=S_IFREG|0664, st_size=25615, ...}, 0) = 0
openat(AT_FDCWD, "graal/substratevm/mxbuild/linux-aarch64/com.oracle.svm.native.libchelper/aarch64/../../../../src/com.oracle.svm.native.libchelper/src/cpuid.c", O_RDONLY|O_CLOEXEC) = 12
```