### PR TITLE
Fix URL rewrites with support for more digests

### DIFF
--- a/mx_urlrewrites.py
+++ b/mx_urlrewrites.py
@@ -192,7 +192,7 @@ class URLRewrite(object):
         # Make sure to use str rather than unicode.
         # Some code paths elsewhere depend on this.
         self.replacement = str(replacement)
-        self.digest = str(digest) if digest else None
+        self.digest = digest if digest else None
 
     def _rewrite(self, url):
         match = self.pattern.match(url)


### PR DESCRIPTION
The changes in 74fd67ab233d5a7447215213944f96204fc2bf64 left a cast in from when `digest` was just a string, this breaks when `digest` is an instance of `Digest`. Looks like simple removal of the cast works fine (at least it does in our local infrastructure).