### PR TITLE
Support for musl-based Linux

### DIFF
--- a/java/com.oracle.jvmtiasmagent/src/jvmtiasmgent.c
+++ b/java/com.oracle.jvmtiasmagent/src/jvmtiasmgent.c
@@ -29,7 +29,7 @@
 #include <time.h>
 #include <limits.h>
 #include <pthread.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <arpa/inet.h>
 
 #include <jni.h>

--- a/mx.mx/suite.py
+++ b/mx.mx/suite.py
@@ -840,6 +840,15 @@ suite = {
             "cflags" : ["-fPIC", "-Wall", "-Werror", "-O", "-g", "-DJVMTI_ASM_ARCH=riscv64", "-std=gnu99"],
           }
         },
+        "linux-musl": {
+          "amd64": {
+            "cflags" : ["-fPIC", "-Wall", "-Werror", "-Wno-error=cpp", "-O", "-g", "-DJVMTI_ASM_ARCH=amd64", "-std=gnu99"],
+            "ldflags" : ["-lrt"],
+          },
+          "aarch64": {
+            "cflags" : ["-fPIC", "-Wall", "-Werror", "-Wno-error=cpp", "-O", "-g", "-DJVMTI_ASM_ARCH=aarch64", "-std=gnu99"],
+          },
+        },
         "darwin": {
             "<others>": {
                 "ignore": "mac is currently not supported",

--- a/mx.mx/suite.py
+++ b/mx.mx/suite.py
@@ -840,15 +840,6 @@ suite = {
             "cflags" : ["-fPIC", "-Wall", "-Werror", "-O", "-g", "-DJVMTI_ASM_ARCH=riscv64", "-std=gnu99"],
           }
         },
-        "linux-musl": {
-          "amd64": {
-            "cflags" : ["-fPIC", "-Wall", "-Werror", "-Wno-error=cpp", "-O", "-g", "-DJVMTI_ASM_ARCH=amd64", "-std=gnu99"],
-            "ldflags" : ["-lrt"],
-          },
-          "aarch64": {
-            "cflags" : ["-fPIC", "-Wall", "-Werror", "-Wno-error=cpp", "-O", "-g", "-DJVMTI_ASM_ARCH=aarch64", "-std=gnu99"],
-          },
-        },
         "darwin": {
             "<others>": {
                 "ignore": "mac is currently not supported",

--- a/mx.py
+++ b/mx.py
@@ -2445,7 +2445,7 @@ class Suite(object):
 
         if os_arch:
             os_variant_list = [get_os() + '-' + v for v in [get_os_variant()] if v]
-            os_attrs = Suite._pop_any([get_os()] + os_variant_list + ['<others>'], os_arch)
+            os_attrs = Suite._pop_any(os_variant_list + [get_os(), '<others>'], os_arch)
             if os_attrs:
                 arch_attrs = Suite._pop_any([get_arch(), '<others>'], os_attrs)
                 if arch_attrs is not None:


### PR DESCRIPTION
A couple of fixes related to musl-based Linux support:
* Changed the order in which OS attributes are examined: most specific variant should come first, e.g. `linux-musl`, then `linux`, then `<others>`
* Added `-Wno-error=cpp` for `linux-musl` so that it doesn't complain about nonstandard headers such as `<sys/errno.h>`

This is needed to take advantage of https://github.com/oracle/graal/pull/3141