### PR TITLE
Do not format field annotations in the Eclipse code formatter.

### DIFF
--- a/eclipse-settings/org.eclipse.jdt.core.prefs
+++ b/eclipse-settings/org.eclipse.jdt.core.prefs
@@ -137,6 +137,7 @@ org.eclipse.jdt.core.compiler.taskPriorities=NORMAL,HIGH,NORMAL
 org.eclipse.jdt.core.compiler.taskTags=TODO,FIXME,XXX
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression=16
+org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field=0
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation=0
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant=48
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call=16


### PR DESCRIPTION
We need to bump the version of the Eclipse code formatter from 4.14 to 4.24. In order to do so, I had to introduce this change in config, to not format annotations in fields.