### PR TITLE
More improved SDK lookup.

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -26,13 +26,13 @@ jobs:
       - name: Style dependencies
         run: |
           cat common.json |
-            jq -r '.deps.common.packages | to_entries[] | select(.key | startswith("pip:")) | (.key | split(":")[1]) + .value' |
+            jq -r '.pip | to_entries[] | .key + .value' |
             xargs pip install
       - run: pylint --version
       - name: Download and set up Eclipse dependency
         run: |
-          ECLIPSE_ORG_VERSION=$(cat common.json | jq -r '.downloads.eclipse.eclipse_org.version')
-          ECLIPSE_ORG_TIMESTAMP=$(cat common.json | jq -r '.downloads.eclipse.eclipse_org.timestamp')
+          ECLIPSE_ORG_VERSION=$(cat common.json | jq -r '.eclipse.short_version')
+          ECLIPSE_ORG_TIMESTAMP=$(cat common.json | jq -r '.eclipse.timestamp')
           wget --no-verbose https://archive.eclipse.org/eclipse/downloads/drops4/R-${ECLIPSE_ORG_VERSION}-${ECLIPSE_ORG_TIMESTAMP}/eclipse-SDK-${ECLIPSE_ORG_VERSION}-linux-gtk-x86_64.tar.gz -O $ECLIPSE_TAR
           tar -C ${{ github.workspace }}/.. -xf $ECLIPSE_TAR
       - name: mx gate

--- a/mx_ide_intellij.py
+++ b/mx_ide_intellij.py
@@ -132,7 +132,12 @@ def intellij_read_sdks():
     xmlSdks.sort(key=verSort, reverse=True)
 
     sdk_version_regexes = {
-        intellij_java_sdk_type: re.compile(r'^java\s+version\s+"([^"]+)"$|^(Oracle OpenJDK )?version\s+(.+)$|^([\d._]+)$'),
+        # Examples:
+        #   java version "21"
+        #   GraalVM version 21 (vendor name may change)
+        intellij_java_sdk_type: re.compile(r'^java\s+version\s+"([^"]+)"$|'
+                                           r'^(?:.+ )?version\s+(.+)$|'
+                                           r'^([\d._]+)$'),
         intellij_python_sdk_type: re.compile(r'^Python\s+(.+)$'),
 
         # Examples:
@@ -170,7 +175,7 @@ def intellij_read_sdks():
             sdk_version = sdk.find("version").get("value")
             match = version_re.match(sdk_version)
             if match:
-                version = match.group(1)
+                version = next(filter(None, match.groups()), None)
                 lang = sdk_languages[kind]
                 if kind == intellij_python_sdk_type:
                     import mx_enter

--- a/mx_ide_intellij.py
+++ b/mx_ide_intellij.py
@@ -106,7 +106,8 @@ def intellijinit(args, refreshOnly=False, doFsckProjects=True, mx_python_modules
 
 def intellij_read_sdks():
     sdks = dict()
-    if mx.is_linux() or mx.is_openbsd() or mx.is_sunos() or mx.is_windows():
+    # https://www.jetbrains.com/help/idea/2023.2/directories-used-by-the-ide-to-store-settings-caches-plugins-and-logs.html
+    if mx.is_linux() or mx.is_openbsd() or mx.is_sunos():
         xmlSdks = glob.glob(os.path.expanduser("~/.IdeaIC*/config/options/jdk.table.xml")) + \
           glob.glob(os.path.expanduser("~/.IntelliJIdea*/config/options/jdk.table.xml")) + \
           glob.glob(os.path.expanduser("~/.config/JetBrains/IdeaIC*/options/jdk.table.xml")) + \
@@ -117,6 +118,12 @@ def intellij_read_sdks():
           glob.glob(os.path.expanduser("~/Library/Application Support/JetBrains/IntelliJIdea*/options/jdk.table.xml")) + \
           glob.glob(os.path.expanduser("~/Library/Preferences/IdeaIC*/options/jdk.table.xml")) + \
           glob.glob(os.path.expanduser("~/Library/Preferences/IntelliJIdea*/options/jdk.table.xml"))
+    elif mx.is_windows():
+        xmlSdks = \
+            glob.glob(os.path.expandvars("%APPDATA%/JetBrains/IdeaIC*/options/jdk.table.xml")) + \
+            glob.glob(os.path.expandvars("%APPDATA%/JetBrains/IntelliJIdea*/options/jdk.table.xml")) + \
+            glob.glob(os.path.expandvars("%LOCALAPPDATA%/JetBrains/IdeaIC*/options/jdk.table.xml")) + \
+            glob.glob(os.path.expandvars("%LOCALAPPDATA%/JetBrains/IntelliJIdea*/options/jdk.table.xml"))
     else:
         mx.warn(f"Location of IntelliJ SDK definitions on {mx.get_os()} is unknown")
         return sdks


### PR DESCRIPTION
This PR:
1. Fixes a bug that only the first branch in `sdk_version_regexes` can be retrieved by `match.group(1)`;
2. Support more JDK vendors to suppress warning;
3. Try to support `mx intellijinit` on windows.

@dougxc 

Before:
```
$ mx intellijinit
Parsing /Users/yyc/Library/Application Support/JetBrains/IntelliJIdea2023.2/options/jdk.table.xml for SDK definitions
  Found Python SDK /Users/yyc/.local/miniforge3/bin/python with values {'name': 'Python 3.9 (base)', 'type': 'Python SDK', 'version': '3.10.9'}
WARNING:   Couldn't understand JavaSDK version specification "Eclipse Temurin version 19.0.1" for /Users/yyc/.sdkman/candidates/java/19.0.1-tem
  Found Java SDK /Users/yyc/.sdkman/candidates/java/19.0.1-tem with values {'name': '19', 'type': 'JavaSDK', 'version': '19.0.1'}
WARNING:   Couldn't understand JavaSDK version specification "GraalVM version 20" for /Users/yyc/.sdkman/candidates/java/labs-20-b10
WARNING:   Couldn't understand JavaSDK version specification "Amazon Corretto version 1.8.0_362" for /Users/yyc/.sdkman/candidates/java/8.0.362-amzn
WARNING:   Couldn't understand JavaSDK version specification "Eclipse Temurin version 11.0.18" for /Users/yyc/.sdkman/candidates/java/11.0.18-tem
  Found Java SDK /Users/yyc/IdeaProjects/jdk/build/labs-21-debug/images/graal-builder-jdk with values {'name': '21', 'type': 'JavaSDK', 'version': '21'}
WARNING:   Couldn't understand JavaSDK version specification "Eclipse Temurin version 20" for /Users/yyc/.sdkman/candidates/java/20-tem
  Found Python SDK /usr/bin/python3 with values {'name': 'Python 3.9', 'type': 'Python SDK', 'version': '3.9.6'}
  Found Python SDK /Users/yyc/.local/miniconda3/envs/yitian_env/bin/python3.11 with values {'name': 'Python 3.11 (yitian_env)', 'type': 'Python SDK', 'version': '3.11.4'}
```

After:
```
$ mx intellijinit                  
Parsing /Users/yyc/Library/Application Support/JetBrains/IntelliJIdea2023.2/options/jdk.table.xml for SDK definitions
  Found Python SDK /Users/yyc/.local/miniforge3/bin/python with values {'name': 'Python 3.9 (base)', 'type': 'Python SDK', 'version': '3.10.9'}
  Found Java SDK /Users/yyc/.sdkman/candidates/java/19.0.1-tem with values {'name': 'labs-20', 'type': 'JavaSDK', 'version': '19.0.1'}
  Found Java SDK /Users/yyc/.sdkman/candidates/java/labs-20-b10 with values {'name': '20', 'type': 'JavaSDK', 'version': '20'}
  Found Java SDK /Users/yyc/.sdkman/candidates/java/8.0.362-amzn with values {'name': 'corretto-1.8', 'type': 'JavaSDK', 'version': '1.8.0_362'}
  Found Java SDK /Users/yyc/.sdkman/candidates/java/11.0.18-tem with values {'name': 'temurin-11', 'type': 'JavaSDK', 'version': '11.0.18'}
  Found Java SDK /Users/yyc/IdeaProjects/jdk/build/labs-21-debug/images/graal-builder-jdk with values {'name': '21', 'type': 'JavaSDK', 'version': '21'}
  Found Java SDK /Users/yyc/.sdkman/candidates/java/20-tem with values {'name': 'temurin-20', 'type': 'JavaSDK', 'version': '20'}
  Found Python SDK /usr/bin/python3 with values {'name': 'Python 3.9', 'type': 'Python SDK', 'version': '3.9.6'}
  Found Python SDK /Users/yyc/.local/miniconda3/envs/yitian_env/bin/python3.11 with values {'name': 'Python 3.11 (yitian_env)', 'type': 'Python SDK', 'version': '3.11.4'}
```