### PR TITLE
[GR-51173] Improve computation of suite root dirs.

### DIFF
--- a/common.json
+++ b/common.json
@@ -4,7 +4,7 @@
     "Jsonnet files should not include this file directly but use ci/common.jsonnet instead."
   ],
 
-  "mx_version": "7.4.1",
+  "mx_version": "7.5.2",
 
   "COMMENT.jdks": "When adding or removing JDKs keep in sync with JDKs in ci/common.jsonnet",
   "jdks": {

--- a/src/mx/_impl/mx.py
+++ b/src/mx/_impl/mx.py
@@ -19255,7 +19255,7 @@ def main():
         abort(1, killsig=signal.SIGINT)
 
 # The version must be updated for every PR (checked in CI) and the comment should reflect the PR's issue
-version = VersionSpec("7.5.2")  # GR-50424 Add custom rss percentile tracker, based on the ps command.
+version = VersionSpec("7.6.0")  # [GR-51173] Improve computation of suite root dirs.
 
 _mx_start_datetime = datetime.utcnow()
 _last_timestamp = _mx_start_datetime

--- a/src/mx/_impl/mx.py
+++ b/src/mx/_impl/mx.py
@@ -3099,7 +3099,8 @@ class SourceSuite(Suite):
                 mx_vcs_root = join(current_dir, '.mx_vcs_root')
                 if exists(hocon) or exists(mx_vcs_root):
                     vc_dir = current_dir
-                    # don't break here to get the top most directory as the vc_dir
+                    # return the match with the "deepest nesting", like `VC.get_vc_root()` does.
+                    break
                 if os.path.splitdrive(current_dir)[1] == os.sep:
                     break
                 current_dir = dirname(current_dir)

--- a/src/mx/_impl/mx.py
+++ b/src/mx/_impl/mx.py
@@ -3086,24 +3086,21 @@ class Repository(SuiteConstituent):
 class SourceSuite(Suite):
     """A source suite"""
     def __init__(self, mxDir, primary=False, load=True, internal=False, importing_suite=None, foreign=None, **kwArgs):
-        if foreign:
-            vc, vc_dir = VC.get_vc_root(mxDir, abortOnError=False)
-        else:
-            vc, vc_dir = VC.get_vc_root(dirname(mxDir), abortOnError=False)
+        candidate_root_dir = realpath(mxDir if foreign else dirname(mxDir))
+        vc, vc_dir = VC.get_vc_root(candidate_root_dir, abortOnError=False)
         if not vc_dir:
-            current_dir = realpath(dirname(mxDir))
             while True:
                 # Use the heuristic of a 'ci.hocon' or '.mx_vcs_root' file being
                 # at the root of a repo that contains multiple suites.
-                hocon = join(current_dir, 'ci.hocon')
-                mx_vcs_root = join(current_dir, '.mx_vcs_root')
+                hocon = join(candidate_root_dir, 'ci.hocon')
+                mx_vcs_root = join(candidate_root_dir, '.mx_vcs_root')
                 if exists(hocon) or exists(mx_vcs_root):
-                    vc_dir = current_dir
+                    vc_dir = candidate_root_dir
                     # return the match with the "deepest nesting", like `VC.get_vc_root()` does.
                     break
-                if os.path.splitdrive(current_dir)[1] == os.sep:
+                if os.path.splitdrive(candidate_root_dir)[1] == os.sep:
                     break
-                current_dir = dirname(current_dir)
+                candidate_root_dir = dirname(candidate_root_dir)
         Suite.__init__(self, mxDir, primary, internal, importing_suite, load, vc, vc_dir, foreign=foreign, **kwArgs)
         logvv(f"SourceSuite.__init__({mxDir}), got vc={self.vc}, vc_dir={self.vc_dir}")
         self.projects = []


### PR DESCRIPTION
To locate the root dir of a suite, mx:
* checks if the suite is contained in one or more multiple VCS, returning the one with the deepest nesting
* if no VCS is found, looks at .mx_vcs_root and ci.hocon files

We should try both approaches and return the "most nested" result (that is, the longest path, which we assume it's the closest to the suite).