### PR TITLE
Make note about MX_BUILD_EXPLODED conditional on it not being true

### DIFF
--- a/src/mx/_impl/mx_ide_eclipse.py
+++ b/src/mx/_impl/mx_ide_eclipse.py
@@ -484,8 +484,9 @@ def eclipseinit_cli(args):
     mx.log('       Projects needed for development can be opened conveniently using the generated Suite working sets from the context menu.')
     mx.log(' 5) Update the type filters (Preferences -> Java -> Appearance -> Type Filters) so that `jdk.*` and `org.graalvm.*` are not filtered.')
     mx.log('    Without this, code completion will not work for JVMCI and Graal code.')
-    mx.log('')
-    mx.log('Note that setting MX_BUILD_EXPLODED=true can improve Eclipse build times. See "Exploded builds" in the mx README.md.')
+    if mx.get_env('MX_BUILD_EXPLODED', None) != 'true':
+        mx.log('')
+        mx.log('Note that setting MX_BUILD_EXPLODED=true can improve Eclipse build times. See "Exploded builds" in the mx README.md.')
     mx.log('----------------------------------------------')
 
     if _EclipseJRESystemLibraries:


### PR DESCRIPTION
This is really a very minor things, though, every time I do a `mx eclipseinit` and it reminds me of MX_BUILD_EXPLODED, I spend a few minutes figuring out whether I got the config wrong.

By adding the check, the note is only printed when the configuration is something other than `MX_BUILD_EXPLODED=true`.