### PR TITLE
Enable build support for JEP 493 enabled base JDKs

### DIFF
--- a/src/mx/_impl/mx_jardistribution.py
+++ b/src/mx/_impl/mx_jardistribution.py
@@ -98,6 +98,7 @@ class JARDistribution(mx.Distribution, mx.ClasspathDependency):
         else:
             self._sources_path = '<uninitialized>'
 
+        self.extra_javac_processors = []
         self.archiveparticipants = []
         self.mainClass = mainClass
         self.javaCompliance = mx.JavaCompliance(javaCompliance) if javaCompliance else None
@@ -284,6 +285,18 @@ class JARDistribution(mx.Distribution, mx.ClasspathDependency):
 
     def origin(self):
         return mx.Dependency.origin(self)
+
+    def set_extra_javac_processor(self, processor):
+        """
+        Adds an extra javac arguments processor when compiling this JARDistribution
+
+        :param processor: a processor which must define method __process__ taking the
+                          following 1 argument:
+                          :param module_desc: The JavaModuleDescriptor for this jar
+                                              distribution.
+                          :rtype: A list of strings suitable to be passed to javac
+        """
+        self.extra_javac_processors.append(processor)
 
     def classpath_repr(self, resolve=True):
         if resolve and not exists(self.path):

--- a/src/mx/_impl/mx_jardistribution.py
+++ b/src/mx/_impl/mx_jardistribution.py
@@ -98,7 +98,7 @@ class JARDistribution(mx.Distribution, mx.ClasspathDependency):
         else:
             self._sources_path = '<uninitialized>'
 
-        self.extra_javac_processors = []
+        self.module_info_compilation_participants = []
         self.archiveparticipants = []
         self.mainClass = mainClass
         self.javaCompliance = mx.JavaCompliance(javaCompliance) if javaCompliance else None
@@ -286,17 +286,16 @@ class JARDistribution(mx.Distribution, mx.ClasspathDependency):
     def origin(self):
         return mx.Dependency.origin(self)
 
-    def set_extra_javac_processor(self, processor):
+    def add_module_info_compilation_participant(self, participant):
         """
-        Adds an extra javac arguments processor when compiling this JARDistribution
+        Adds a callable that can add javac args when compiling ``module-info.java``
+        for the Java module derived from this distribution.
 
-        :param processor: a processor which must define method __process__ taking the
-                          following 1 argument:
-                          :param module_desc: The JavaModuleDescriptor for this jar
-                                              distribution.
-                          :rtype: A list of strings suitable to be passed to javac
+        :param participant: a callable that takes a JavaModuleDescriptor (describing this
+                            distribution's Java module) and returns a list of
+                            args to be added to javac when compiling ``module-info.java``
         """
-        self.extra_javac_processors.append(processor)
+        self.module_info_compilation_participants.append(participant)
 
     def classpath_repr(self, resolve=True):
         if resolve and not exists(self.path):

--- a/src/mx/_impl/mx_javamodules.py
+++ b/src/mx/_impl/mx_javamodules.py
@@ -1097,12 +1097,6 @@ def make_java_module(dist, jdk, archive, javac_daemon=None, alt_module_info_name
                         modulepath_jars.extend((join(jdk_jmods, m) for m in os.listdir(jdk_jmods) if m.endswith('.jmod')))
                     if modulepath_jars:
                         javac_args.append('--module-path=' + safe_path_arg(os.pathsep.join(modulepath_jars)))
-                    # Let distributions which need javac customizations do their work.
-                    if dist.extra_javac_processors:
-                        for proc in dist.extra_javac_processors:
-                            extra_args = proc.__process__(jmd)
-                            for arg in extra_args:
-                                javac_args.append(arg)
 
                     if concealedRequires:
                         for module, packages in concealedRequires.items():
@@ -1115,6 +1109,12 @@ def make_java_module(dist, jdk, archive, javac_daemon=None, alt_module_info_name
                     # modules in qualified exports (not sure how to avoid these since we build modules
                     # separately).
                     javac_args.append('-Xlint:-options,-module')
+                    # Let distributions which need javac customizations do their work.
+                    if dist.module_info_compilation_participants:
+                        for part in dist.module_info_compilation_participants:
+                            extra_args = part(jmd)
+                            for arg in extra_args:
+                                javac_args.append(arg)
                     javac_args.append(safe_path_arg(module_info_java))
 
                     # Convert javac args to @args file

--- a/src/mx/_impl/mx_javamodules.py
+++ b/src/mx/_impl/mx_javamodules.py
@@ -521,6 +521,9 @@ def _check_uses(uses, context):
             mx.abort(f"specification of service {use} must use non-binary name of nested class (i.e. replace '$' with '.')", context=context)
     return uses
 
+def _jlink_libraries():
+    return not (mx.get_opts().no_jlinking or mx.env_var_to_bool('NO_JLINKING'))
+
 def make_java_module(dist, jdk, archive, javac_daemon=None, alt_module_info_name=None):
     """
     Creates a Java module from a distribution.
@@ -1085,14 +1088,23 @@ def make_java_module(dist, jdk, archive, javac_daemon=None, alt_module_info_name
                     # The --system=none and --limit-modules options are used to support distribution defined modules
                     # that override non-upgradeable modules in the source JDK (e.g. org.graalvm.sdk is part of a
                     # GraalVM JDK). This means --module-path needs to contain the jmods for the JDK modules.
-                    javac_args.append('--system=none')
+                    if _jlink_libraries():
+                        javac_args.append('--system=none')
                     if requires_clean:
                         javac_args.append('--limit-modules=' + ','.join(requires_clean.keys()))
                     jdk_jmods = (mx.get_opts().jmods_dir or join(jdk.home, 'jmods'))
-                    if not exists(jdk_jmods):
+                    if _jlink_libraries() and not exists(jdk_jmods):
                         mx.abort('Missing directory containing JMOD files: ' + jdk_jmods)
-                    modulepath_jars.extend((join(jdk_jmods, m) for m in os.listdir(jdk_jmods) if m.endswith('.jmod')))
-                    javac_args.append('--module-path=' + safe_path_arg(os.pathsep.join(modulepath_jars)))
+                    if _jlink_libraries():
+                        modulepath_jars.extend((join(jdk_jmods, m) for m in os.listdir(jdk_jmods) if m.endswith('.jmod')))
+                    if modulepath_jars:
+                        javac_args.append('--module-path=' + safe_path_arg(os.pathsep.join(modulepath_jars)))
+                    if not _jlink_libraries():
+                        graal_jar = [m.jarpath for m in modulepath if m.name == "jdk.graal.compiler"]
+                    # Upgrade module path for compilation of module-info.java files when not jlinking the JDK
+                    # This is a no-op for regular GraalVM JDK builds.
+                    if graal_jar:
+                        javac_args.append('--upgrade-module-path=' + safe_path_arg(os.pathsep.join(graal_jar)))
 
                     if concealedRequires:
                         for module, packages in concealedRequires.items():

--- a/src/mx/_impl/mx_javamodules.py
+++ b/src/mx/_impl/mx_javamodules.py
@@ -1097,12 +1097,12 @@ def make_java_module(dist, jdk, archive, javac_daemon=None, alt_module_info_name
                         modulepath_jars.extend((join(jdk_jmods, m) for m in os.listdir(jdk_jmods) if m.endswith('.jmod')))
                     if modulepath_jars:
                         javac_args.append('--module-path=' + safe_path_arg(os.pathsep.join(modulepath_jars)))
-                    if not use_jmods:
-                        graal_jar = [m.jarpath for m in modulepath if m.name == "jdk.graal.compiler"]
-                    # Upgrade module path for compilation of module-info.java files when not using jmods from the JDK
-                    # This is a no-op for regular GraalVM JDK builds.
-                    if graal_jar:
-                        javac_args.append('--upgrade-module-path=' + safe_path_arg(os.pathsep.join(graal_jar)))
+                    # Let distributions which need javac customizations do their work.
+                    if dist.extra_javac_processors:
+                        for proc in dist.extra_javac_processors:
+                            extra_args = proc.__process__(jmd)
+                            for arg in extra_args:
+                                javac_args.append(arg)
 
                     if concealedRequires:
                         for module, packages in concealedRequires.items():


### PR DESCRIPTION
JEP 493-enabled JDKs won't have a 'jmods' directory by default. For builds with option --no-jlinking the replacement of base JDK-provided non-upgradable modules is not required, nor desired. Allow for builds with no JMODs in that case by checking for this option being in use and if so upgrade the module path when compiling module-info.java files.

Tested with the following on a based JDK without `jmods` folder:
```
$ mx --primary-suite substratevm --no-jlinking --native-images=lib:native-image-agent,lib:native-image-diagnostics-agent --components=ni build
```

Closes #286