### PR TITLE
Make mx support the Loongarch architecture

### DIFF
--- a/mx.mx/suite.py
+++ b/mx.mx/suite.py
@@ -1045,6 +1045,9 @@ suite = {
           },
           "riscv64" : {
             "cflags" : ["-fPIC", "-Wall", "-Werror", "-O", "-g", "-DJVMTI_ASM_ARCH=riscv64", "-std=gnu99"],
+          },
+          "loongarch64" : {
+            "cflags" : ["-fPIC", "-Wall", "-Werror", "-O", "-g", "-DJVMTI_ASM_ARCH=loongarch64", "-std=gnu99"],
           }
         },
         "darwin": {

--- a/src/mx/_impl/mx.py
+++ b/src/mx/_impl/mx.py
@@ -3868,6 +3868,8 @@ def _get_real_arch():
         return 'sparcv9'
     if machine in ['riscv64']:
         return 'riscv64'
+    if machine in ['loongarch64']:
+        return 'loongarch64'
     if machine == 'i386' and is_darwin():
         try:
             # Support for Snow Leopard and earlier version of MacOSX


### PR DESCRIPTION
Hello! I'm from the Loongson team and I'm currently adding support for the Loongarch architecture to GraalVM. At present, most of the unit tests for the Graal Compiler and Truffle can be passed. However, the mx package lacks the relevant architecture information related to Loongarch. Many people in our team are using it, so I'd like to add that information to it.