### PR TITLE
Patch mx thirdpartydeps to print URLs of libraries that have multiple URLs & include urlbase

### DIFF
--- a/src/mx/_impl/mx.py
+++ b/src/mx/_impl/mx.py
@@ -17413,7 +17413,21 @@ def _thirdpartydeps(args):
         if hasattr(lib, "maven") and isinstance(lib.maven, dict) and 'groupId' in lib.maven and 'artifactId' in lib.maven and 'version' in lib.maven:
             print("\tMaven: " + lib.maven['groupId'] + ":" + lib.maven['artifactId'] + ":" + lib.maven['version'])
         elif hasattr(lib, "urls") and len(lib.urls) > 0:
-            print("\tURL: " + lib.urls[0].split('/')[-1])
+            url = lib.urls[0]
+            if hasattr(lib, "urlbase"):
+                url = url.replace("{urlbase}", lib.urlbase)
+            print("\tURL: " + url)
+        elif hasattr(lib, "_orig_attrs"):
+                systems = lib._orig_attrs['os_arch']
+                for opsys in systems:
+                    for architecture in lib._orig_attrs['os_arch'][opsys]:
+                        if 'urls' in lib._orig_attrs['os_arch'][opsys][architecture]:
+                            url = lib._orig_attrs['os_arch'][opsys][architecture]['urls'][0]
+                            if hasattr(lib, "urlbase"):
+                                url = url.replace("{urlbase}", lib.urlbase)
+                            print("\tURL for " + opsys + " running on " + architecture + ": " + url)
+        else:
+            print("\tNo URL?!")
 
         # License
         if hasattr(lib, "theLicense") and lib.theLicense:


### PR DESCRIPTION
Can I please get some reviews on this small patch to address the issue mentioned in #291 

Tested on Linux x86_64 and OSX AArch64