### PR TITLE
Add support for custom Maven repository URLs

### DIFF
--- a/src/mx/_impl/mx.py
+++ b/src/mx/_impl/mx.py
@@ -828,6 +828,7 @@ environment variables:
   MX_CACHE_DIR          Override the default location of the mx download cache. Defaults to `~/.mx/cache`.
   MX_GLOBAL_ENV         Override the default location of the global env file that is always loaded at startup.
                         Defaults to `~/.mx/env`. Can be disabled by setting it to an empty string.
+  MX_MAVEN_REPO_URLS    Comma-separated list of Maven repository base URLs. Defaults to Maven Central repositories.
   MX_GIT_CACHE          Use a cache for git objects during clones.
                          * Setting it to `reference` will clone repositories using the cache and let them
                            reference the cache (if the cache gets deleted these repositories will be
@@ -4566,10 +4567,6 @@ _removed_dists = {}
 _distTemplates = {}
 _licenses = {}
 _repositories = {}
-_mavenRepoBaseURLs = [
-    "https://repo1.maven.org/maven2/",
-    "https://search.maven.org/remotecontent?filepath="
-]
 
 """
 Map of the environment variables loaded by parsing the suites.

--- a/src/mx/_impl/mx_maven.py
+++ b/src/mx/_impl/mx_maven.py
@@ -283,10 +283,29 @@ def maven_local_repository():  # pylint: disable=invalid-name
 
     return _maven_local_repository
 
+_resolved_maven_repo_base_urls = False
+def _get_maven_repo_base_urls():
+    """
+    Gets the Maven repository base URLs from the MX_MAVEN_REPO_URLS environment variable.
+    If not set, returns the default Maven Central repositories.
+    The environment variable should contain a comma-separated list of URLs.
+    """
+    default_urls = [
+        "https://repo1.maven.org/maven2/",
+        "https://search.maven.org/remotecontent?filepath="
+    ]
+    global _resolved_maven_repo_base_urls
+    if _resolved_maven_repo_base_urls is False:
+        urls = mx.get_env('MX_MAVEN_REPO_URLS')
+        if urls:
+            _resolved_maven_repo_base_urls = urls.split(',')
+        else:
+            _resolved_maven_repo_base_urls = default_urls
+    return _resolved_maven_repo_base_urls
 
 def maven_download_urls(groupId, artifactId, version, classifier=None, baseURL=None):
     if baseURL is None:
-        baseURLs = mx._mavenRepoBaseURLs
+        baseURLs = _get_maven_repo_base_urls()
     else:
         baseURLs = [baseURL]
     classifier = f'-{classifier}' if classifier else ''


### PR DESCRIPTION
In some build environments it's required to use custom maven repositories (e.g., internal mirrors). This PR enables the global override of the default maven repositories to satisfy that requirement.

cc @jerboaa 