### PR TITLE
refactor: use += for period, samples, and count accumulation

### DIFF
--- a/src/mx/_impl/mx_proftool.py
+++ b/src/mx/_impl/mx_proftool.py
@@ -1185,8 +1185,8 @@ class PerfOutput:
         for event in self.events:
             e = events_by_address.get(event.pc)
             if e:
-                e.period = e.period + event.period
-                e.samples = e.samples + event.samples
+                e.period += event.period
+                e.samples += event.samples
             else:
                 # avoid mutating the underlying raw event
                 events_by_address[event.pc] = copy.copy(event)
@@ -1201,7 +1201,7 @@ class PerfOutput:
                 count = hot_symbols.get(key)
                 if count is None:
                     count = 0
-                count = count + event.period
+                count += event.period
                 hot_symbols[key] = count
             entries = [(s, d, c) for (s, d), c in hot_symbols.items()]
 


### PR DESCRIPTION
Wow, this is a cool repo! Made a small cleanup in `mx_proftool.py` — replaced manual addition assignments with `+=` in `merge_perf_events` and `get_top_methods`. No behavior change. Hope this helps!